### PR TITLE
Add import from exported files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,72 @@
+IMPORT_VERSION:=20200211_9.0.3
+IMPORT_DIR:=init_config/.current
+
+status:
+	docker-compose ps -a
+
+start:
+	docker-compose up -d
+
+logs:
+	docker-compose logs -f keycloak
+
+logs-init:
+	docker-compose logs -f keycloak-init
+
+down:
+	docker-compose down --remove-orphans
+
+clean:
+	make down
+	docker volume rm --force stuart-keycloak_mysql_data
+	make clean-import-files
+
+init:
+	make clean
+	make prepare-import-files
+	make launch-init
+	echo "Waiting for service..."
+	sleep 10
+	echo "Waiting for service..."
+	sleep 10
+	echo "Waiting for service..."
+	sleep 10
+	echo "Waiting for service..."
+	sleep 10
+	make add-admin
+	make login
+	make import-stuart-realm
+	make stop-init
+	make clean-import-files	
+
+prepare-import-files:
+	mkdir -p ${IMPORT_DIR}
+	cp init_config/${IMPORT_VERSION}/realm-export-*.json ${IMPORT_DIR}
+
+clean-import-files:
+	rm -rf ${IMPORT_DIR}
+
+launch-init:
+	docker-compose up -d keycloak-init
+
+stop-init:
+	docker-compose stop keycloak-init
+	docker-compose rm --force keycloak-init
+
+add-admin:
+	docker-compose exec keycloak-init /opt/jboss/keycloak/bin/add-user-keycloak.sh -u ${KEYCLOAK_USER} -p ${KEYCLOAK_PASSWORD}
+	docker-compose exec keycloak-init /opt/jboss/keycloak/bin/jboss-cli.sh --connect --command=:reload
+
+login:
+	docker-compose run --rm keycloak-cli config credentials --server http://keycloak-init:8080/auth --user ${KEYCLOAK_USER} --password ${KEYCLOAK_PASSWORD} --realm master
+
+prepare-import-clients:
+	cat ${IMPORT_DIR}/realm-export-only-clients.json | grep -B1 "Browser With User Access Verification" | head -1 | sed 's/"id": "\(.*\)",/\1/' | xargs > ${IMPORT_DIR}/old_id.txt
+	docker-compose run --rm keycloak-cli get authentication/flows -r stuart > ${IMPORT_DIR}/flows.txt
+	cat ${IMPORT_DIR}/flows.txt | grep -B1 "Browser With User Access Verification" | head -1 | sed 's/"id" : "\(.*\)",/\1/' | tr '\n' ' ' | xargs > ${IMPORT_DIR}/new_id.txt
+	sed "s/$$(cat ${IMPORT_DIR}/old_id.txt)/$$(cut -c -36 ${IMPORT_DIR}/new_id.txt)/g" ${IMPORT_DIR}/realm-export-only-clients.json > ${IMPORT_DIR}/realm-export-only-clients-updated.json
+
+import-stuart-realm:
+	make prepare-import-clients
+	docker-compose run --rm keycloak-cli create partialImport -r stuart -s ifResourceExists=OVERWRITE -o -f /${IMPORT_DIR}/realm-export-only-clients-updated.json
+	docker-compose run --rm keycloak-cli create partialImport -r stuart -s ifResourceExists=OVERWRITE -o -f /${IMPORT_DIR}/realm-export-only-groups-and-roles.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     networks:
       - dev
 
-  keycloak:
+  keycloak: &keycloak
     image: quay.io/keycloak/keycloak:latest
     environment:
       DB_VENDOR: MYSQL
@@ -60,3 +60,27 @@ services:
     networks:
       - dev
 
+  keycloak-init: &keycloak-init
+    << : *keycloak
+    profiles:
+      - init
+    image: quay.io/keycloak/keycloak:9.0.3
+    environment:
+      JDBC_PARAMS: "useSSL=false"
+      KEYCLOAK_IMPORT: "/init_config/.current/realm-export-base.json"
+    command: "-Dkeycloak.profile.feature.scripts=enabled -Dkeycloak.profile.feature.upload_scripts=enabled"
+    volumes:
+      - "./init_config:/init_config"
+    depends_on:
+      - mysql
+    networks:
+      - dev
+
+  keycloak-cli:
+    << : *keycloak-init
+    profiles:
+      - cli
+    entrypoint: /opt/jboss/keycloak/bin/kcadm.sh
+    volumes:
+      - "./init_config:/init_config"
+      - "./.config_cli:/opt/jboss/.keycloak"

--- a/init_config/20200211_9.0.3/realm-export-base.json
+++ b/init_config/20200211_9.0.3/realm-export-base.json
@@ -1,0 +1,2048 @@
+{
+  "id": "stuart",
+  "realm": "stuart",
+  "displayName": "Stuart",
+  "notBefore": 1607959567,
+  "defaultSignatureAlgorithm": "ES256",
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 300,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 3600,
+  "ssoSessionIdleTimeoutRememberMe": 0,
+  "ssoSessionMaxLifespanRememberMe": 0,
+  "offlineSessionIdleTimeout": 172800,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "permanentLockout": false,
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "defaultRoles": [
+    "uma_authorization",
+    "offline_access"
+  ],
+  "requiredCredentials": [
+    "password"
+  ],
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpSupportedApplications": [
+    "FreeOTP",
+    "Google Authenticator"
+  ],
+  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicySignatureAlgorithms": [
+    "ES256"
+  ],
+  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyRequireResidentKey": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyCreateTimeout": 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+    "ES256"
+  ],
+  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout": 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "scopeMappings": [
+    {
+      "clientScope": "offline_access",
+      "roles": [
+        "offline_access"
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "id": "cd1b8f73-4ac4-4275-aa00-9401e3374a1d",
+      "name": "address",
+      "description": "OpenID Connect built-in scope: address",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${addressScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "e6e11ab6-510a-48b7-ab83-d1dc276aabc4",
+          "name": "address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-address-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute.formatted": "formatted",
+            "user.attribute.country": "country",
+            "user.attribute.postal_code": "postal_code",
+            "userinfo.token.claim": "true",
+            "user.attribute.street": "street",
+            "id.token.claim": "true",
+            "user.attribute.region": "region",
+            "access.token.claim": "true",
+            "user.attribute.locality": "locality"
+          }
+        }
+      ]
+    },
+    {
+      "id": "4d1b5f8e-99e3-47d1-b751-1fba11dc5a63",
+      "name": "email",
+      "description": "OpenID Connect built-in scope: email",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${emailScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "93f84bb2-4cbe-4e63-87ca-faf8cf7a98f3",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "3ac3835d-0385-485a-934d-8318b7c63c93",
+          "name": "email verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "emailVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email_verified",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "id": "3a81dc05-583f-46fa-b905-64abd24e47c1",
+      "name": "graphql",
+      "description": "Carries the GraphQL permission schema attribute mappers",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "c2f5ced0-8dae-4c4b-98e5-583b1ccd8054",
+          "name": "admin_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "false",
+            "user.attribute": "admin_id",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:admin_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "103bf575-9b5e-4f70-9075-c869e2e92a92",
+          "name": "environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "aggregate.attrs": "true",
+            "multivalued": "true",
+            "userinfo.token.claim": "false",
+            "user.attribute": "environments",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d7d51a9c-2603-4c07-a2a2-d317fec88a09",
+          "name": "zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "aggregate.attrs": "true",
+            "multivalued": "true",
+            "userinfo.token.claim": "false",
+            "user.attribute": "zone_codes",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "4e3ff890-a8c0-420b-9cea-23828271c92f",
+          "name": "fleet_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "aggregate.attrs": "true",
+            "multivalued": "true",
+            "userinfo.token.claim": "false",
+            "user.attribute": "fleet_ids",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:fleet_ids",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "736ff81d-844c-42d5-883b-90215c998e96",
+          "name": "client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "aggregate.attrs": "true",
+            "multivalued": "true",
+            "userinfo.token.claim": "false",
+            "user.attribute": "client_ids",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "e46d998f-bde4-4512-b86d-c799e24cc26b",
+          "name": "client_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "false",
+            "user.attribute": "client_id",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "64db4f49-daf4-4c6c-9cc3-d1a31c982329",
+          "name": "driver_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "aggregate.attrs": "false",
+            "multivalued": "false",
+            "userinfo.token.claim": "false",
+            "user.attribute": "driver_id",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:driver_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "be88ed15-d857-4a25-bae4-4cac5ecaa992",
+          "name": "idp",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "false",
+            "user.attribute": "idp",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:idp",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "da1c8819-51d5-44fe-9377-ad31b3afa080",
+          "name": "flags",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "false",
+            "multivalued": "true",
+            "user.attribute": "flags",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:flags",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "53cc28d7-0f05-4f5e-a2da-e3c0fa1f2e7d",
+          "name": "features",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "false",
+            "multivalued": "true",
+            "user.attribute": "features",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:features",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "a98b4f4a-e242-4cfc-b466-d6963bbb588d",
+      "name": "microprofile-jwt",
+      "description": "Microprofile - JWT built-in scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "357535e0-a1af-40fa-9238-c42655f31332",
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "bfb84423-a302-49df-909c-b2d577f32733",
+          "name": "upn",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "upn",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "b72c88c2-f76f-47bb-b225-f6d68762d62a",
+      "name": "offline_access",
+      "description": "OpenID Connect built-in scope: offline_access",
+      "protocol": "openid-connect",
+      "attributes": {
+        "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "id": "456badf7-98e5-418f-81b4-7381d9f621f3",
+      "name": "phone",
+      "description": "OpenID Connect built-in scope: phone",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${phoneScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "b1ff5727-80d9-46d9-8ad2-28928364634d",
+          "name": "phone number",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumber",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "0d5d733f-eedf-4402-a9e8-5015436be8f4",
+          "name": "phone number verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumberVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number_verified",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "id": "5512022e-e817-4e36-b288-0bd7866cc9ea",
+      "name": "profile",
+      "description": "OpenID Connect built-in scope: profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${profileScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "1e4a1a36-8ffa-448f-81c5-72c1be496ea4",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "7f2b4195-8685-4c4d-8cbc-3e837b84daa1",
+          "name": "gender",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "gender",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "gender",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "a90f97bb-22eb-46b6-9668-d9980a927a52",
+          "name": "nickname",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "nickname",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "nickname",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c24512a0-76a1-40b2-8681-135e152c36d3",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "299e423c-4e16-4e83-8e07-05731daaa6b9",
+          "name": "picture",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "picture",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "picture",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "948d2795-2982-4e53-9147-21c67267f95a",
+          "name": "middle name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "middleName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "middle_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "0abdd2d5-c8b6-41ee-aaa4-020cd6d1ab57",
+          "name": "birthdate",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "birthdate",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "birthdate",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "7071871c-7310-473b-be95-5f923979cf62",
+          "name": "updated at",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "updatedAt",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "updated_at",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "5803a398-0a70-4974-9bb0-db1347923f3e",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c2b1bcda-be94-474d-af10-90eff2ae7451",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ac1b0b3f-e5d7-4884-a6bd-42a842443276",
+          "name": "profile",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "profile",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "profile",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "fef5d358-d29c-4641-9e95-6828ffa7a825",
+          "name": "website",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "website",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "website",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "6ad7c82a-6ec3-4208-89e2-9d3f696abe3c",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c1b6ad45-4789-4656-8efb-a470a872b6f7",
+          "name": "zoneinfo",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "zoneinfo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "zoneinfo",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "0bb235ae-a789-47b5-ad3b-1883b45225f0",
+      "name": "role_list",
+      "description": "SAML role list",
+      "protocol": "saml",
+      "attributes": {
+        "consent.screen.text": "${samlRoleListScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "b8ce7cf3-fe12-4016-80e2-253c5f9c8d34",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        }
+      ]
+    },
+    {
+      "id": "8068afab-0c65-4b07-b3be-b8ef6be169f9",
+      "name": "roles",
+      "description": "OpenID Connect scope for add user roles to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${rolesScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "12251252-d119-45ba-9c9c-31cfcbcff006",
+          "name": "client roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "resource_access.${client_id}.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "0d4ee838-4651-49f8-a37c-4453a69882bd",
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "f9959649-534d-4c75-ad60-e982f5233282",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ]
+    },
+    {
+      "id": "27ce23a0-f7b5-4a4a-8f61-47bd83a9e328",
+      "name": "web-origins",
+      "description": "OpenID Connect scope for add allowed web origins to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false",
+        "consent.screen.text": ""
+      },
+      "protocolMappers": [
+        {
+          "id": "66039beb-7c4b-4cfa-9df0-2edab5386c08",
+          "name": "allowed web origins",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-allowed-origins-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ]
+    },
+    {
+      "id": "3ed4016b-bd7d-41a2-916d-158450fa0ef4",
+      "name": "driver:identity",
+      "description": "Allow app to request putting driver ID specifics in the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "This app would like to read your driver identity."
+      },
+      "protocolMappers": [
+        {
+          "id": "7250dd2e-63cc-4466-8cf6-95d7bf41da2c",
+          "name": "srt:driver_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "false",
+            "user.attribute": "driver_id",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:driver_id",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "53895eb2-57e8-4f79-b984-d7430ea0dd42",
+      "name": "client_local",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "a036330a-951f-48de-9a3d-3288b2656cbf",
+          "name": "srt:client_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "9",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_id",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "role_list",
+    "profile",
+    "email",
+    "roles",
+    "web-origins"
+  ],
+  "defaultOptionalClientScopes": [
+    "offline_access",
+    "address",
+    "phone",
+    "microprofile-jwt"
+  ],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection": "1; mode=block",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer": {},
+  "loginTheme": "stuartdefault",
+  "eventsEnabled": true,
+  "eventsListeners": [
+    "jboss-logging"
+  ],
+  "enabledEventTypes": [
+    "SEND_RESET_PASSWORD",
+    "UPDATE_CONSENT_ERROR",
+    "GRANT_CONSENT",
+    "REMOVE_TOTP",
+    "REVOKE_GRANT",
+    "UPDATE_TOTP",
+    "LOGIN_ERROR",
+    "CLIENT_LOGIN",
+    "RESET_PASSWORD_ERROR",
+    "IMPERSONATE_ERROR",
+    "CODE_TO_TOKEN_ERROR",
+    "CUSTOM_REQUIRED_ACTION",
+    "RESTART_AUTHENTICATION",
+    "IMPERSONATE",
+    "UPDATE_PROFILE_ERROR",
+    "LOGIN",
+    "UPDATE_PASSWORD_ERROR",
+    "CLIENT_INITIATED_ACCOUNT_LINKING",
+    "TOKEN_EXCHANGE",
+    "LOGOUT",
+    "REGISTER",
+    "CLIENT_REGISTER",
+    "IDENTITY_PROVIDER_LINK_ACCOUNT",
+    "UPDATE_PASSWORD",
+    "CLIENT_DELETE",
+    "FEDERATED_IDENTITY_LINK_ERROR",
+    "IDENTITY_PROVIDER_FIRST_LOGIN",
+    "CLIENT_DELETE_ERROR",
+    "VERIFY_EMAIL",
+    "CLIENT_LOGIN_ERROR",
+    "RESTART_AUTHENTICATION_ERROR",
+    "EXECUTE_ACTIONS",
+    "REMOVE_FEDERATED_IDENTITY_ERROR",
+    "TOKEN_EXCHANGE_ERROR",
+    "PERMISSION_TOKEN",
+    "SEND_IDENTITY_PROVIDER_LINK_ERROR",
+    "EXECUTE_ACTION_TOKEN_ERROR",
+    "SEND_VERIFY_EMAIL",
+    "EXECUTE_ACTIONS_ERROR",
+    "REMOVE_FEDERATED_IDENTITY",
+    "IDENTITY_PROVIDER_POST_LOGIN",
+    "IDENTITY_PROVIDER_LINK_ACCOUNT_ERROR",
+    "UPDATE_EMAIL",
+    "REGISTER_ERROR",
+    "REVOKE_GRANT_ERROR",
+    "EXECUTE_ACTION_TOKEN",
+    "LOGOUT_ERROR",
+    "UPDATE_EMAIL_ERROR",
+    "CLIENT_UPDATE_ERROR",
+    "UPDATE_PROFILE",
+    "CLIENT_REGISTER_ERROR",
+    "FEDERATED_IDENTITY_LINK",
+    "SEND_IDENTITY_PROVIDER_LINK",
+    "SEND_VERIFY_EMAIL_ERROR",
+    "RESET_PASSWORD",
+    "CLIENT_INITIATED_ACCOUNT_LINKING_ERROR",
+    "UPDATE_CONSENT",
+    "REMOVE_TOTP_ERROR",
+    "VERIFY_EMAIL_ERROR",
+    "SEND_RESET_PASSWORD_ERROR",
+    "CLIENT_UPDATE",
+    "CUSTOM_REQUIRED_ACTION_ERROR",
+    "IDENTITY_PROVIDER_POST_LOGIN_ERROR",
+    "UPDATE_TOTP_ERROR",
+    "CODE_TO_TOKEN",
+    "GRANT_CONSENT_ERROR",
+    "IDENTITY_PROVIDER_FIRST_LOGIN_ERROR"
+  ],
+  "adminEventsEnabled": true,
+  "adminEventsDetailsEnabled": false,
+  "identityProviders": [
+    {
+      "alias": "pontica",
+      "displayName": "Google from Pontica",
+      "internalId": "6f48af48-b1a7-4c0c-ae6c-ef9b8c2da048",
+      "providerId": "oidc",
+      "enabled": true,
+      "updateProfileFirstLoginMode": "on",
+      "trustEmail": true,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "authenticateByDefault": false,
+      "linkOnly": false,
+      "firstBrokerLoginFlowAlias": "first broker login",
+      "postBrokerLoginFlowAlias": "Client Access Authenticator",
+      "config": {
+        "hideOnLoginPage": "false",
+        "validateSignature": "",
+        "userInfoUrl": "https://openidconnect.googleapis.com/v1/userinfo",
+        "uiLocales": "",
+        "acceptsPromptNoneForwardFromClient": "",
+        "tokenUrl": "https://oauth2.googleapis.com/token",
+        "clientId": "105908661118-0vr0h5ho7518unl3p00vvjgo4ll5vjan.apps.googleusercontent.com",
+        "backchannelSupported": "",
+        "issuer": "https://accounts.google.com",
+        "useJwksUrl": "true",
+        "loginHint": "",
+        "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth?hd=ponticasolutions.com",
+        "clientAuthMethod": "client_secret_post",
+        "disableUserInfo": "",
+        "clientSecret": "**********",
+        "prompt": "",
+        "guiOrder": "2",
+        "defaultScope": "openid profile email"
+      }
+    },
+    {
+      "alias": "google",
+      "internalId": "543c4bf5-b51d-4056-9f4a-938cdd2d99ab",
+      "providerId": "google",
+      "enabled": true,
+      "updateProfileFirstLoginMode": "on",
+      "trustEmail": true,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "authenticateByDefault": false,
+      "linkOnly": false,
+      "firstBrokerLoginFlowAlias": "first broker login",
+      "postBrokerLoginFlowAlias": "Client Access Authenticator",
+      "config": {
+        "hideOnLoginPage": "",
+        "offlineAccess": "",
+        "acceptsPromptNoneForwardFromClient": "",
+        "clientId": "406759240425-tns0suq1ur38hre3ssdo0qerc9vhnqst.apps.googleusercontent.com",
+        "disableUserInfo": "",
+        "hostedDomain": "stuart.com",
+        "userIp": "",
+        "clientSecret": "**********",
+        "useJwksUrl": "true"
+      }
+    }
+  ],
+  "identityProviderMappers": [
+    {
+      "id": "822ca862-0975-42ed-8d55-0aef192a7733",
+      "name": "idp",
+      "identityProviderAlias": "google",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "google",
+        "attribute": "idp"
+      }
+    }
+  ],
+  "components": {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+      {
+        "id": "f778a489-2ac5-49e7-b591-54cefff26efd",
+        "name": "Trusted Hosts",
+        "providerId": "trusted-hosts",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "host-sending-registration-request-must-match": [
+            "true"
+          ],
+          "client-uris-must-match": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "0a1dd0af-9f5d-4303-bbf8-85cf4476cb76",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-usermodel-attribute-mapper",
+            "saml-user-attribute-mapper",
+            "saml-role-list-mapper",
+            "oidc-full-name-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "saml-user-property-mapper",
+            "oidc-address-mapper",
+            "oidc-usermodel-property-mapper"
+          ]
+        }
+      },
+      {
+        "id": "89efaec5-f573-4d4f-8800-9c0e35a6b50e",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "cc58da9d-a99b-4aad-963b-48e4a2c0798a",
+        "name": "Max Clients Limit",
+        "providerId": "max-clients",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "max-clients": [
+            "200"
+          ]
+        }
+      },
+      {
+        "id": "36547dca-c90d-4f58-866e-f85b541f9387",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "7fec7fac-ebd0-478b-9b62-aa8e41db43a7",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "saml-user-attribute-mapper",
+            "oidc-usermodel-property-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "saml-user-property-mapper",
+            "oidc-address-mapper",
+            "oidc-full-name-mapper",
+            "saml-role-list-mapper"
+          ]
+        }
+      },
+      {
+        "id": "1dac8e5a-d618-4926-afad-1303ae30cfc1",
+        "name": "Consent Required",
+        "providerId": "consent-required",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "b39b51e4-09f3-4af3-a8de-d3233836e33f",
+        "name": "Full Scope Disabled",
+        "providerId": "scope",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      }
+    ],
+    "org.keycloak.keys.KeyProvider": [
+      {
+        "id": "33239f9d-e793-451f-9d08-627ed1375daa",
+        "name": "fallback-HS256",
+        "providerId": "hmac-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "-100"
+          ],
+          "algorithm": [
+            "HS256"
+          ]
+        }
+      },
+      {
+        "id": "fb1c33a0-f2d3-4539-824c-16f3892e1c72",
+        "name": "ecdsa-generated",
+        "providerId": "ecdsa-generated",
+        "subComponents": {},
+        "config": {
+          "ecdsaEllipticCurveKey": [
+            "P-256"
+          ],
+          "active": [
+            "true"
+          ],
+          "priority": [
+            "0"
+          ],
+          "enabled": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "55eae381-7fcd-47ab-a740-b183545bcc38",
+        "name": "fallback-RS256",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "-100"
+          ],
+          "algorithm": [
+            "RS256"
+          ]
+        }
+      }
+    ]
+  },
+  "internationalizationEnabled": false,
+  "supportedLocales": [
+    ""
+  ],
+  "authenticationFlows": [
+    {
+      "id": "5d0d2ebe-7ae3-474a-ae35-3fdff1df8a46",
+      "alias": "Account verification options",
+      "description": "Method with which to verity the existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-email-verification",
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "flowAlias": "Verify Existing Account by Re-authentication",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "b75a3c2a-f5bc-4296-b191-ae04b9151250",
+      "alias": "Authentication Options",
+      "description": "Authentication options.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "basic-auth",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "basic-auth-otp",
+          "requirement": "DISABLED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "requirement": "DISABLED",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "f5662006-0277-4547-9837-e80686100b36",
+      "alias": "Browser",
+      "description": "",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "requirement": "ALTERNATIVE",
+          "priority": 0,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "requirement": "ALTERNATIVE",
+          "priority": 1,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-page-form",
+          "requirement": "ALTERNATIVE",
+          "priority": 2,
+          "flowAlias": "Form",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "adc721b2-765e-4560-a6c1-5697bf2272a1",
+      "alias": "Browser - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "cb587590-17dd-43a8-944f-7a2aed1ed0aa",
+      "alias": "Browser With User Access Verification",
+      "description": "browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "requirement": "REQUIRED",
+          "priority": 31,
+          "flowAlias": "Browser",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        },
+        {
+          "authenticator": "script-client-authenticator.js",
+          "requirement": "REQUIRED",
+          "priority": 32,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "5d07efb7-0151-4632-b77f-60a82011c23f",
+      "alias": "Client Access Authenticator",
+      "description": "",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "script-client-authenticator.js",
+          "requirement": "REQUIRED",
+          "priority": 0,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "b3224ba1-ca2d-4470-909b-fa3e97c18499",
+      "alias": "Direct Grant - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "direct-grant-validate-otp",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "753c6467-3fe1-4068-9797-b45920e3a99e",
+      "alias": "First broker login - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "0decf3cb-7ac3-43d6-b3c0-79b8fe66e144",
+      "alias": "Form",
+      "description": "",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "requirement": "REQUIRED",
+          "priority": 0,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "446f2dcc-cd84-4d3d-832d-ecdefe38702c",
+      "alias": "Handle Existing Account",
+      "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-confirm-link",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "flowAlias": "Account verification options",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "dca943a1-baa1-4b9c-ba21-004a3c8d6129",
+      "alias": "Reset - Conditional OTP",
+      "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "reset-otp",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "05589f17-2167-402e-97ba-6ed9ec1b5c21",
+      "alias": "User creation or linking",
+      "description": "Flow for the existing/non-existing user alternatives",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "create unique user config",
+          "authenticator": "idp-create-user-if-unique",
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "flowAlias": "Handle Existing Account",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "c1a6c049-8b1c-4258-9ed9-92a3515f9cb5",
+      "alias": "Verify Existing Account by Re-authentication",
+      "description": "Reauthentication of existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-username-password-form",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "flowAlias": "First broker login - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "48620dfa-7d8d-400d-8112-b8231bcc2927",
+      "alias": "browser",
+      "description": "browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "requirement": "DISABLED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "flowAlias": "forms",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "5a76108b-bc1c-4f5d-89f8-7d5d601d91d9",
+      "alias": "clients",
+      "description": "Base authentication for clients",
+      "providerId": "client-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "client-secret",
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "client-jwt",
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "client-secret-jwt",
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "client-x509",
+          "requirement": "ALTERNATIVE",
+          "priority": 40,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "f8a257a0-b734-46a5-8c85-c54b03e74a23",
+      "alias": "direct grant",
+      "description": "OpenID Connect Resource Owner Grant",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "direct-grant-validate-username",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "direct-grant-validate-password",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "CONDITIONAL",
+          "priority": 30,
+          "flowAlias": "Direct Grant - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "2c2205af-536d-44ca-bcdc-ce1239ecf1f6",
+      "alias": "docker auth",
+      "description": "Used by Docker clients to authenticate against the IDP",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "8cd65670-e350-4004-b181-920839676ce6",
+      "alias": "first broker login",
+      "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "review profile config",
+          "authenticator": "idp-review-profile",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "flowAlias": "User creation or linking",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "ca5ba922-5c8d-4dd4-a421-9a9ac31e22ce",
+      "alias": "forms",
+      "description": "Username, password, otp and other auth forms.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "flowAlias": "Browser - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "ced3b856-80fe-4939-b173-a099282f98e6",
+      "alias": "http challenge",
+      "description": "An authentication flow based on challenge-response HTTP Authentication Schemes",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "no-cookie-redirect",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "flowAlias": "Authentication Options",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "24d66d4f-88e4-4ef7-b310-4a5d08b084b3",
+      "alias": "registration",
+      "description": "registration flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "flowAlias": "registration form",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "489aedd6-f889-4bad-b7d6-853bcdbd4fad",
+      "alias": "registration form",
+      "description": "registration form",
+      "providerId": "form-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-user-creation",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-profile-action",
+          "requirement": "REQUIRED",
+          "priority": 40,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-password-action",
+          "requirement": "REQUIRED",
+          "priority": 50,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-recaptcha-action",
+          "requirement": "DISABLED",
+          "priority": 60,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "960f3fce-7ee7-4ded-985b-0cf7f709b089",
+      "alias": "reset credentials",
+      "description": "Reset credentials for a user if they forgot their password or something",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "reset-credentials-choose-user",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "reset-credential-email",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "reset-password",
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "CONDITIONAL",
+          "priority": 40,
+          "flowAlias": "Reset - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "dc081de8-9b1d-40c5-b712-183bbef5a448",
+      "alias": "saml ecp",
+      "description": "SAML ECP Profile Authentication Flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "http-basic-authenticator",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "id": "81d487e6-b3ad-462b-9f30-527c32f959fe",
+      "alias": "create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
+      }
+    },
+    {
+      "id": "e3c8db16-e690-4d25-bf9b-9f3c0c4c139d",
+      "alias": "group-manager",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "238f0f56-249b-4182-9078-a6d76f7b9809",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "2ffc6aff-bf69-4995-866e-6b630c502418",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "4ff2cd2c-7367-4c78-b11a-f97631ed8975",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "de8968d7-b600-446f-b81d-404d7e6e1000",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "9b1e6914-905d-48c3-8af2-7f0fd29898f7",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "4d42a886-6664-4350-954a-be9eef4cb718",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "abafdc79-eac6-4d80-b353-1e6fc6f48af6",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "29588348-335d-45c6-b596-ddd9a15f1f4e",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "717f6c75-c5f1-425b-9f4f-0213cf0abab5",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "ac455d62-13ec-4863-80f6-ca11f1b11b3d",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "86bc657a-5a8d-4547-af57-537c75340420",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "7fe80a0e-5c59-4789-a52a-9ef73a0e226c",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "2dd8dc94-9e4f-4c17-8c4e-a2ee073b90f4",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "7821f341-5c28-472e-9890-e446f1a36947",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "40d3f618-f19a-4412-9a9b-ea93fde42e8a",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "2d4879af-f12d-4535-81eb-d0466234b76e",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "893bc087-6e9a-48bc-8227-418010fe822b",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "1788dc9a-3435-4c8c-a72b-94a2e433bd0d",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "5a3829fe-561c-4d8d-bf6c-5e89a59e8556",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "6ae8333a-c371-4ceb-bf16-18ddd09411f6",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "f5ae5140-f4b3-4543-978c-4c511c665467",
+      "alias": "groups-management.groups-management",
+      "config": {
+        "condUserRole": "terexa-test-ugm.groups-management"
+      }
+    },
+    {
+      "id": "6b9cf769-2880-4973-b9f4-b4832bb90cbc",
+      "alias": "review profile config",
+      "config": {
+        "update.profile.on.first.login": "missing"
+      }
+    },
+    {
+      "id": "ae9cf032-4ef4-4516-8a98-cc7dd4d62ea4",
+      "alias": "terexa-test-ugm.manager",
+      "config": {
+        "condUserRole": "terexa-test-ugm.manager"
+      }
+    }
+  ],
+  "requiredActions": [
+    {
+      "alias": "CONFIGURE_TOTP",
+      "name": "Configure OTP",
+      "providerId": "CONFIGURE_TOTP",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 10,
+      "config": {}
+    },
+    {
+      "alias": "terms_and_conditions",
+      "name": "Terms and Conditions",
+      "providerId": "terms_and_conditions",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 20,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PASSWORD",
+      "name": "Update Password",
+      "providerId": "UPDATE_PASSWORD",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 30,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PROFILE",
+      "name": "Update Profile",
+      "providerId": "UPDATE_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 40,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 50,
+      "config": {}
+    },
+    {
+      "alias": "update_user_locale",
+      "name": "Update User Locale",
+      "providerId": "update_user_locale",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 1000,
+      "config": {}
+    }
+  ],
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "attributes": {
+    "displayName": "Stuart",
+    "webAuthnPolicyAuthenticatorAttachment": "not specified",
+    "_browser_header.xRobotsTag": "none",
+    "webAuthnPolicyAttestationConveyancePreferencePasswordless": "not specified",
+    "webAuthnPolicyRequireResidentKeyPasswordless": "not specified",
+    "webAuthnPolicySignatureAlgorithmsPasswordless": "ES256",
+    "webAuthnPolicyRpEntityName": "keycloak",
+    "webAuthnPolicyAvoidSameAuthenticatorRegisterPasswordless": "false",
+    "failureFactor": "30",
+    "webAuthnPolicyAuthenticatorAttachmentPasswordless": "not specified",
+    "actionTokenGeneratedByUserLifespan": "300",
+    "maxDeltaTimeSeconds": "43200",
+    "webAuthnPolicySignatureAlgorithms": "ES256",
+    "webAuthnPolicyRpEntityNamePasswordless": "keycloak",
+    "offlineSessionMaxLifespan": "5184000",
+    "_browser_header.contentSecurityPolicyReportOnly": "",
+    "bruteForceProtected": "false",
+    "webAuthnPolicyRpIdPasswordless": "",
+    "actionTokenGeneratedByUserLifespan.reset-credentials": "300",
+    "_browser_header.contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "_browser_header.xXSSProtection": "1; mode=block",
+    "_browser_header.xFrameOptions": "SAMEORIGIN",
+    "_browser_header.strictTransportSecurity": "max-age=31536000; includeSubDomains",
+    "webAuthnPolicyUserVerificationRequirement": "not specified",
+    "permanentLockout": "false",
+    "quickLoginCheckMilliSeconds": "1000",
+    "webAuthnPolicyCreateTimeout": "0",
+    "webAuthnPolicyRequireResidentKey": "not specified",
+    "webAuthnPolicyRpId": "",
+    "webAuthnPolicyAttestationConveyancePreference": "not specified",
+    "maxFailureWaitSeconds": "900",
+    "minimumQuickLoginWaitSeconds": "60",
+    "defaultSignatureAlgorithm": "ES256",
+    "webAuthnPolicyCreateTimeoutPasswordless": "0",
+    "webAuthnPolicyAvoidSameAuthenticatorRegister": "false",
+    "webAuthnPolicyUserVerificationRequirementPasswordless": "not specified",
+    "_browser_header.xContentTypeOptions": "nosniff",
+    "actionTokenGeneratedByAdminLifespan": "43200",
+    "waitIncrementSeconds": "60",
+    "offlineSessionMaxLifespanEnabled": "false"
+  },
+  "keycloakVersion": "9.0.0",
+  "userManagedAccessAllowed": false
+}

--- a/init_config/20200211_9.0.3/realm-export-only-clients.json
+++ b/init_config/20200211_9.0.3/realm-export-only-clients.json
@@ -1,0 +1,11309 @@
+{
+  "id": "stuart",
+  "realm": "stuart",
+  "displayName": "Stuart",
+  "notBefore": 1607959567,
+  "defaultSignatureAlgorithm": "ES256",
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 300,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 3600,
+  "ssoSessionIdleTimeoutRememberMe": 0,
+  "ssoSessionMaxLifespanRememberMe": 0,
+  "offlineSessionIdleTimeout": 172800,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "permanentLockout": false,
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "defaultRoles": [
+    "uma_authorization",
+    "offline_access"
+  ],
+  "requiredCredentials": [
+    "password"
+  ],
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpSupportedApplications": [
+    "FreeOTP",
+    "Google Authenticator"
+  ],
+  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicySignatureAlgorithms": [
+    "ES256"
+  ],
+  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyRequireResidentKey": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyCreateTimeout": 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+    "ES256"
+  ],
+  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout": 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "scopeMappings": [
+    {
+      "clientScope": "offline_access",
+      "roles": [
+        "offline_access"
+      ]
+    }
+  ],
+  "clientScopeMappings": {
+    "realm-management": [
+      {
+        "client": "management-groups",
+        "roles": [
+          "manage-users"
+        ]
+      }
+    ],
+    "account": [
+      {
+        "client": "account-console",
+        "roles": [
+          "manage-account"
+        ]
+      }
+    ]
+  },
+  "clients": [
+    {
+      "id": "3d128093-4279-423c-858e-cfe2f3e28ec8",
+      "clientId": "package-incentives",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost:3000/"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "c8171c4c-6f94-46ca-996c-e6e3020e314b",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"packages\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "172dec28-db13-45d9-8b30-e0dbc12f94a7",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "b2ee2434-eed4-4210-b16e-b8b9720e2f8c",
+          "name": "srt:zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "6bdb16d9-77ff-41a2-a0f5-a7a473a0ed4f",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"beta\", \"qa\", \"development\", \"ephemeral\", \"sandbox\", \"test\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "30d64005-7aa8-4f33-808b-d71867a3a91a",
+          "name": "srt:features",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"packageIncentives\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:features",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "850d9236-a2e1-47da-a4d0-74f1eccf913d",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"package\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "245060cb-4df4-4d2f-bfb0-da19b1252a3e",
+          "name": "srt:client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "d99bfab6-b2b8-4a49-85ba-452309fe40ad",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "b4fce790-539b-46ed-9be7-02d67a42cadb",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "role_list"
+      ],
+      "optionalClientScopes": []
+    },
+    {
+      "id": "1fcc8d0e-3612-4078-b8de-274ddb9f6bac",
+      "clientId": "monocle",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost:3000/"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "access.token.lifespan": "86400",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "login_theme": "keycloak",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "bb65de1e-2e09-4161-97a5-8f971b2ec084",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "de0b5ad2-65ee-48b5-a01a-bb0180c9b418",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"packageSearch\", \"deleteSavedSearches\", \"schedulePackage\", \"updatePackageReference\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "ce265790-6b7c-436e-99ba-faf651654097",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "481f7e82-cf76-4deb-8eb3-3d9bfa2129f2",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"whoami\", \"search\", \"zone\", \"deliveries\", \"delivery\", \"drivers\", \"driver\", \"calculateDistanceAndDuration\", \"savedSearches\", \"zones\", \"clients\", \"fleets\", \"preOrderETA\", \"packages\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "29063d66-bf12-400c-b513-f46a9320720f",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "54edfde8-d833-4899-9a28-2fbb662bd2e7",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"beta\",\"production\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "70b2f416-0c62-4473-a86d-970c6633a618",
+          "name": "srt:zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "JSON"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt",
+        "graphql"
+      ],
+      "authorizationSettings": {
+        "allowRemoteResourceManagement": true,
+        "policyEnforcementMode": "ENFORCING",
+        "resources": [
+          {
+            "name": "Default Resource",
+            "type": "urn:monocle-woop:resources:default",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "7d5e2d74-6145-4b9f-bb1a-955d8fee65dc",
+            "uris": [
+              "/*"
+            ]
+          }
+        ],
+        "policies": [
+          {
+            "id": "fe189546-8424-4621-98e9-bbeeb7f9142d",
+            "name": "Default Policy",
+            "description": "A policy that grants access only for users within this realm",
+            "type": "js",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "code": "// by default, grants any permission associated with this policy\n$evaluation.grant();\n"
+            }
+          },
+          {
+            "id": "10f64e2d-a120-45a8-9481-1477510dd8fb",
+            "name": "Default Permission",
+            "description": "A permission that applies to the default resource type",
+            "type": "resource",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "defaultResourceType": "urn:monocle-woop:resources:default",
+              "applyPolicies": "[\"Default Policy\"]"
+            }
+          }
+        ],
+        "scopes": [],
+        "decisionStrategy": "AFFIRMATIVE"
+      }
+    },
+    {
+      "id": "30121009-c365-4241-824f-aa22694f4f3c",
+      "clientId": "app-rasa",
+      "name": "Rasa",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://dkang.ngrok.io/webhooks/stuart_sso/webhook*",
+        "https://rasa.beta.internal.stuart.com/webhooks/stuart_sso/webhook*",
+        "http://gemma-stuart.ngrok.io/webhooks/stuart_sso/webhook*",
+        "https://rasa.stuart.com/webhooks/stuart_sso/webhook*",
+        "https://rasa.internal.stuart.com/webhooks/stuart_sso/webhook*",
+        "https://rasa.beta.stuart.com/webhooks/stuart_sso/webhook*",
+        "http://127.0.0.1:9999/oauth/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "access.token.lifespan": "300",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "login_theme": "stuartdefault",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "db891e11-efa8-4af8-8a61-4ccb1aa20641",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"package\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "941f810d-c8dc-477e-9a7e-a082fae44675",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"production\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "d760f75d-a381-4209-a00d-bdd1e3e0825e",
+          "name": "srt:flags",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"pii\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:flags",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "e29166c3-62c8-4ea6-8b32-717d5731c956",
+          "name": "srt:fleet_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:fleet_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "1fb974b4-7ffa-48e7-b638-33c7ab6053d2",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "336b101a-2509-4f0f-b607-bf70a99f62f9",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "161c7e09-f893-4f37-965b-1457139c7ae8",
+          "name": "srt:zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "c8c6a24d-3271-41ac-8f03-aabdf535c6eb",
+          "name": "srt:client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "ad4e1e42-4afc-4445-857b-43d7a61a1b14",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"packages\", \"deliveries\",\"tasks\",\"whoami\",\"delivery\",\"driver\",\"businessRules\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "2469c598-fbfb-4ca7-bea7-6d9c0150bbaa",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "b1147c98-5084-490c-88e0-b56310a86439",
+          "name": "srt:features",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"dma\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:features",
+            "jsonType.label": "JSON"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "role_list",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt",
+        "graphql"
+      ]
+    },
+    {
+      "id": "2460eab1-fc04-4a6c-afc6-497b5d984852",
+      "clientId": "ship3-fraud-production",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost:3000/"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "271b5203-9c86-437c-8b9b-d3c39c823725",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ef1fefd9-dc2a-4657-83b1-5488e6d7471f",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"pushFraudEstimationsForTransportType\", \"pushFraudEstimationsForBike\", \"pushFraudEstimationsForDetour\", \"pushFraudEstimationsForGps\", \"pushFraudEstimationsForSpeed\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "f9b44e6b-d00a-4326-b2c4-fcb141f459d6",
+          "name": "srt:features",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"pushFraudEstimations\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:features",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "990a271a-930e-4229-9225-10214213058f",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"production\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "fe994ff9-bd48-49fc-8332-7e4540d81abf",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d921223e-91a1-4ea1-8ef0-7dd6afb3c0ae",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "role_list"
+      ],
+      "optionalClientScopes": []
+    },
+    {
+      "id": "48210d50-58be-4cc1-95b9-e02d8c7d9595",
+      "clientId": "admin-cli",
+      "name": "${client_admin-cli}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost:9999/oauth/callback",
+        "http://127.0.0.1:9999/oauth/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.force.post.binding": "false",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "094c6053-e738-4719-814d-4605636d5784",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "8323ea17-3f40-4bc0-a525-a8fd1abdb5ab",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "5ba88425-b771-405a-aa60-1a48a8171a33",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "9ff3f2e4-5ef6-43c8-bacc-8f94ab2b6a42",
+      "clientId": "management-groups",
+      "name": "Management Groups",
+      "description": "Organize users into groups and apply your conditions to the groups. All users within a management group automatically inherit the attributes applied to the group",
+      "rootUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "https://flow.beta.stuart.com/oauth/callback/apps",
+        "https://flow-eph-wbxj7z.dev.stuart.com/oauth/callback/apps",
+        "https://flow-eph-r4koi8.dev.stuart.com/oauth/callback/apps",
+        "https://flow-eph-28ed5q.dev.stuart.com/oauth/callback/apps",
+        "https://flow-eph-iklw2q.dev.stuart.com/oauth/callback/apps",
+        "https://flow-eph-ylio0k.dev.stuart.com/oauth/callback/apps",
+        "https://flow.stuart.com/oauth/callback/apps",
+        "https://flow-eph-y7jwxv.dev.stuart.com/oauth/callback/apps",
+        "http://localhost:3000/oauth/callback/apps",
+        "https://flow-eph-1maztj.dev.stuart.com/oauth/callback/apps",
+        "https://flow-eph-rk1mbq.dev.stuart.com/oauth/callback/apps",
+        "https://flow-eph-ttr4i0.dev.stuart.com/oauth/callback/apps",
+        "https://flow-eph-n1nm7s.dev.stuart.com/oauth/callback/apps",
+        "https://flow-eph-0kkypd.dev.stuart.com/oauth/callback/apps",
+        "http://127.0.0.1:9999/oauth/callback",
+        "https://flow-eph-hirui7.dev.stuart.com/oauth/callback/apps",
+        "https://flow-eph-jinpl5.dev.stuart.com/oauth/callback/apps",
+        "https://flow-eph-emzcoe.dev.stuart.com/oauth/callback/apps",
+        "https://flow-eph-mdanrp.dev.stuart.com/oauth/callback/apps"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {
+        "browser": "e0c1c019-ee8a-4015-8eb4-3032468ee181"
+      },
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "8b4f8f3f-8c14-4053-b349-1b9d9a771e53",
+          "name": "srt:restrict_user_access",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "true",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "false",
+            "claim.name": "srt:restrict_user_access",
+            "jsonType.label": "boolean"
+          }
+        },
+        {
+          "id": "934cb17f-091e-4fac-8ac6-9917e1bebd2c",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"whoami\", \"userGroup\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "c1b884bf-bc3d-4622-a2d3-ba9da298e18f",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d3ab6826-a14b-4610-a76a-fde41ffb8201",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"userGroup\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "f028630d-e1fa-47e8-9375-b381ce5e1f42",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "86def97a-ff94-45d6-af37-4162a9d48f55",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "role_list",
+        "profile",
+        "roles",
+        "graphql",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ],
+      "authorizationSettings": {
+        "allowRemoteResourceManagement": true,
+        "policyEnforcementMode": "ENFORCING",
+        "resources": [
+          {
+            "name": "Default Resource",
+            "type": "urn:management-groups:resources:default",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "d29d78c3-f72e-4652-858d-42a799cea63f",
+            "uris": [
+              "/*"
+            ]
+          }
+        ],
+        "policies": [
+          {
+            "id": "aa3e45f2-3ca4-4790-8787-141634104f58",
+            "name": "Default Policy",
+            "description": "A policy that grants access only for users within this realm",
+            "type": "js",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "code": "// by default, grants any permission associated with this policy\n$evaluation.grant();\n"
+            }
+          },
+          {
+            "id": "e75d2a55-fafd-48a0-8efd-dafb781312a2",
+            "name": "Default Permission",
+            "description": "A permission that applies to the default resource type",
+            "type": "resource",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "defaultResourceType": "urn:management-groups:resources:default",
+              "applyPolicies": "[\"Default Policy\"]"
+            }
+          }
+        ],
+        "scopes": [],
+        "decisionStrategy": "UNANIMOUS"
+      }
+    },
+    {
+      "id": "0190189f-99a8-4b92-baa4-29ec78910e92",
+      "clientId": "ops-live-monitoring",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://127.0.0.1:9999/oauth/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "78897f7d-dc2e-4d6d-bf3e-20a6afc28af5",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"whoami\", \"delivery\", \"deliveries\", \"driver\", \"drivers\", \"calculateDistanceandDuration\", \"clients\", \"fleets\", \"preOrderETA\", \"zones\", \"geocode\", \"reverseGeocode\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "5f206e0a-c87a-422f-bc6b-fc8ce87f217f",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "4f03cc6d-2285-46dd-b25f-6cfa2299f10a",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "b6507c65-ed3f-496d-bfe4-282fc8ccba11",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d6b68237-4974-48fe-85b7-4b21f315446f",
+          "name": "srt:fleet_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:fleet_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "c2bb4e5e-309f-470e-a5b2-654b7b9e09ff",
+          "name": "srt:client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "5ce7ff5a-d096-4e1d-8837-d5179e13fcf4",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"beta\", \"qa\", \"development\", \"ephemeral\", \"sandbox\", \"test\", \"production\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "f8f7c65e-031f-4d15-a683-f33b6f823dd2",
+          "name": "srt:flags",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"pii\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:flags",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "ba8c237d-130f-4dbb-9770-b232884279fd",
+          "name": "srt:zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "JSON"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "graphql",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "6d271ea3-273b-4f13-b9da-adb8f0833725",
+      "clientId": "account",
+      "name": "${client_account}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/stuart/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "defaultRoles": [
+        "view-profile",
+        "manage-account"
+      ],
+      "redirectUris": [
+        "/realms/stuart/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "8bd6a034-2618-4522-a9c8-f79746cf5bd7",
+      "clientId": "account-console",
+      "name": "${client_account-console}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/stuart/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "/realms/stuart/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "44563d7d-1f15-4488-b04a-e93f467f9530",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "d4e488da-7d26-4629-bb49-7a34da483f73",
+      "clientId": "demand-management",
+      "rootUrl": "",
+      "adminUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost/"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "login_theme": "keycloak",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "711bc0dc-58bf-413a-814d-9c427b935fa2",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "5c92645b-bd84-40c6-b296-d9ca9f99ecb6",
+          "name": "srt:fleet_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:fleet_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "fdbee1f1-85eb-4d7d-a4ad-423d94bbf5c2",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ab7f6545-5156-4c01-a356-e745b8a51c44",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c2035033-d55f-4e83-bce3-c998de8abf94",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"whoami\", \"preOrderETA\", \"deliveries\", \"drivers\", \"zones\", \"packages\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "bb46c8d8-e301-4250-8e42-efebe4b254a3",
+          "name": "srt:client_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "\"0\"",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_id",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "60937862-e203-47d3-a9a4-342f10d5887c",
+          "name": "srt:subscriptions",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "jsonType.label": "JSON",
+            "claim.value": "[]",
+            "userinfo.token.claim": "false"
+          }
+        },
+        {
+          "id": "e67a14ca-396b-49c9-9b89-c7020cfa2086",
+          "name": "srt:client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "fa721af5-e040-4758-9806-17e1a1cd65b3",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"beta\", \"qa\", \"development\", \"ephemeral\", \"sandbox\", \"test\", \"production\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "027115b0-275e-4fc4-b3cf-1ea4746a9c93",
+          "name": "srt:zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "90594950-0802-4cc5-ab00-7905e3a02767",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "role_list",
+        "microprofile-jwt"
+      ],
+      "optionalClientScopes": [
+        "client_local",
+        "graphql"
+      ],
+      "authorizationSettings": {
+        "allowRemoteResourceManagement": true,
+        "policyEnforcementMode": "ENFORCING",
+        "resources": [
+          {
+            "name": "Default Resource",
+            "type": "urn:demand-management:resources:default",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "6b87ae7f-c4de-45c9-831f-087fc84247e0",
+            "uris": [
+              "/*"
+            ]
+          }
+        ],
+        "policies": [
+          {
+            "id": "8ab5c113-921a-4ac3-9c6a-640d5d416d04",
+            "name": "Default Policy",
+            "description": "A policy that grants access only for users within this realm",
+            "type": "js",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "code": "// by default, grants any permission associated with this policy\n$evaluation.grant();\n"
+            }
+          },
+          {
+            "id": "8734b5fb-eb98-4ac8-a8f4-2adca0bdeada",
+            "name": "Default Permission",
+            "description": "A permission that applies to the default resource type",
+            "type": "resource",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "defaultResourceType": "urn:demand-management:resources:default",
+              "applyPolicies": "[\"Default Policy\"]"
+            }
+          }
+        ],
+        "scopes": [],
+        "decisionStrategy": "UNANIMOUS"
+      }
+    },
+    {
+      "id": "50828751-a409-4785-8a6a-c0d967f94990",
+      "clientId": "broker",
+      "name": "${client_broker}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "e70873a5-a48c-40df-bb74-46267955de69",
+      "clientId": "dma",
+      "name": "Driver Mobile App",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost:3000/oauth/callback.html",
+        "http://localhost:3000/oauth/callback",
+        "http://127.0.0.1:9999/oauth/callback",
+        "https://flow.beta.stuart.com/oauth/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 1585150919,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.force.post.binding": "false",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "login_theme": "flow",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "1f7ff0c3-d35a-4849-87f8-392a899b7304",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c3b156ce-a3c5-4757-afd6-ea4eb12d9da3",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d7ec3bd9-f4c1-4e4d-8319-369231ddd05d",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "role_list",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt",
+        "graphql"
+      ]
+    },
+    {
+      "id": "e8da9541-b137-4b19-8d6a-78fabe569b11",
+      "clientId": "je-london",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://example./com"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.force.post.binding": "false",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "d40933ba-484a-477e-b72d-1e4b1c6e1506",
+          "name": "je_sandbox_producrtion",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"production\", \"sandbox\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "4a933116-bdb4-444c-b977-50b63f654396",
+          "name": "hardcoded_je_client_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "46679",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "https://stuart\\.com/client_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "cfe098d4-7ef3-4194-aaa3-cb4bbad25f40",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "sandbox",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "fdec5257-ec8d-466f-bab5-3ed0fb312d16",
+          "name": "dfsdfsd",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "getPackages,getDriverInvitations,getFleets",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "graphql",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "ee9c91bc-44ab-461c-967b-fa9dae7fe889",
+      "clientId": "qa-test-creating-packages",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "f24630fc-5977-43e8-8e62-f015ec347e2d",
+      "clientId": "realm-management",
+      "name": "${client_realm-management}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "authorizationServicesEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {
+        "browser": "1fb83126-c3f6-43e9-891b-99b61064e812"
+      },
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ],
+      "authorizationSettings": {
+        "allowRemoteResourceManagement": false,
+        "policyEnforcementMode": "ENFORCING",
+        "resources": [
+          {
+            "name": "client.resource.6cc67e45-49c8-45dd-8ea1-25f90cbf30e3",
+            "type": "Client",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "715d0616-5f83-4d05-863d-de337f6395cc",
+            "uris": [],
+            "scopes": [
+              {
+                "name": "view"
+              },
+              {
+                "name": "map-roles-client-scope"
+              },
+              {
+                "name": "map-roles"
+              },
+              {
+                "name": "configure"
+              },
+              {
+                "name": "manage"
+              },
+              {
+                "name": "token-exchange"
+              },
+              {
+                "name": "map-roles-composite"
+              }
+            ]
+          },
+          {
+            "name": "client.resource.9ff3f2e4-5ef6-43c8-bacc-8f94ab2b6a42",
+            "type": "Client",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "4b9c27b8-2230-4e84-8b2d-efd543965ceb",
+            "uris": [],
+            "scopes": [
+              {
+                "name": "view"
+              },
+              {
+                "name": "map-roles-client-scope"
+              },
+              {
+                "name": "map-roles"
+              },
+              {
+                "name": "configure"
+              },
+              {
+                "name": "manage"
+              },
+              {
+                "name": "token-exchange"
+              },
+              {
+                "name": "map-roles-composite"
+              }
+            ]
+          },
+          {
+            "name": "client.resource.36570e43-8272-426a-998f-a528a23a6d23",
+            "type": "Client",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "a4449b9f-ea29-4ec2-963b-55cdb0834701",
+            "uris": [],
+            "scopes": [
+              {
+                "name": "view"
+              },
+              {
+                "name": "map-roles-client-scope"
+              },
+              {
+                "name": "map-roles"
+              },
+              {
+                "name": "configure"
+              },
+              {
+                "name": "manage"
+              },
+              {
+                "name": "token-exchange"
+              },
+              {
+                "name": "map-roles-composite"
+              }
+            ]
+          },
+          {
+            "name": "client.resource.d60ee94d-207f-4fef-94d5-75d80649951a",
+            "type": "Client",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "ec938045-0933-46b8-b875-2df7e3be5be2",
+            "uris": [],
+            "scopes": [
+              {
+                "name": "view"
+              },
+              {
+                "name": "map-roles-client-scope"
+              },
+              {
+                "name": "map-roles"
+              },
+              {
+                "name": "configure"
+              },
+              {
+                "name": "manage"
+              },
+              {
+                "name": "token-exchange"
+              },
+              {
+                "name": "map-roles-composite"
+              }
+            ]
+          },
+          {
+            "name": "client.resource.6b1c153e-b80a-4889-9851-98a34bef59c8",
+            "type": "Client",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "4b1a882a-6a6a-4d6d-b137-799107cd0170",
+            "uris": [],
+            "scopes": [
+              {
+                "name": "view"
+              },
+              {
+                "name": "map-roles-client-scope"
+              },
+              {
+                "name": "map-roles"
+              },
+              {
+                "name": "configure"
+              },
+              {
+                "name": "manage"
+              },
+              {
+                "name": "token-exchange"
+              },
+              {
+                "name": "map-roles-composite"
+              }
+            ]
+          },
+          {
+            "name": "client.resource.d8012a59-8fe5-41c2-b3c9-5dc7907889f3",
+            "type": "Client",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "2572113a-6fbb-4989-9d06-49e6a11aea16",
+            "uris": [],
+            "scopes": [
+              {
+                "name": "view"
+              },
+              {
+                "name": "map-roles-client-scope"
+              },
+              {
+                "name": "map-roles"
+              },
+              {
+                "name": "configure"
+              },
+              {
+                "name": "manage"
+              },
+              {
+                "name": "token-exchange"
+              },
+              {
+                "name": "map-roles-composite"
+              }
+            ]
+          }
+        ],
+        "policies": [
+          {
+            "id": "4e869f75-d765-48bd-b653-a9464f276696",
+            "name": "stuart-mc-token-exchange",
+            "type": "client",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "clients": "[\"stuart-mc\"]"
+            }
+          },
+          {
+            "id": "33a5829f-c467-4813-bc02-a7beb6ec103a",
+            "name": "manage.permission.client.6cc67e45-49c8-45dd-8ea1-25f90cbf30e3",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.6cc67e45-49c8-45dd-8ea1-25f90cbf30e3\"]",
+              "scopes": "[\"manage\"]"
+            }
+          },
+          {
+            "id": "abca7bd5-e3a8-4a0c-a02c-d8cfe9e6cd2b",
+            "name": "configure.permission.client.6cc67e45-49c8-45dd-8ea1-25f90cbf30e3",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.6cc67e45-49c8-45dd-8ea1-25f90cbf30e3\"]",
+              "scopes": "[\"configure\"]"
+            }
+          },
+          {
+            "id": "d68de31c-6b6d-4d61-991c-34c918a0c816",
+            "name": "view.permission.client.6cc67e45-49c8-45dd-8ea1-25f90cbf30e3",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.6cc67e45-49c8-45dd-8ea1-25f90cbf30e3\"]",
+              "scopes": "[\"view\"]"
+            }
+          },
+          {
+            "id": "8e6005b7-c9f9-4528-ade3-c51253b090a5",
+            "name": "map-roles.permission.client.6cc67e45-49c8-45dd-8ea1-25f90cbf30e3",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.6cc67e45-49c8-45dd-8ea1-25f90cbf30e3\"]",
+              "scopes": "[\"map-roles\"]"
+            }
+          },
+          {
+            "id": "3a623adc-ca6a-432b-bd89-6bc250881ff0",
+            "name": "map-roles-client-scope.permission.client.6cc67e45-49c8-45dd-8ea1-25f90cbf30e3",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.6cc67e45-49c8-45dd-8ea1-25f90cbf30e3\"]",
+              "scopes": "[\"map-roles-client-scope\"]"
+            }
+          },
+          {
+            "id": "5cce32c7-f825-488b-be3a-10baecc16c2d",
+            "name": "map-roles-composite.permission.client.6cc67e45-49c8-45dd-8ea1-25f90cbf30e3",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.6cc67e45-49c8-45dd-8ea1-25f90cbf30e3\"]",
+              "scopes": "[\"map-roles-composite\"]"
+            }
+          },
+          {
+            "id": "5ce1d800-6e98-408a-bcae-633b5b310013",
+            "name": "token-exchange.permission.client.6cc67e45-49c8-45dd-8ea1-25f90cbf30e3",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.6cc67e45-49c8-45dd-8ea1-25f90cbf30e3\"]",
+              "scopes": "[\"token-exchange\"]",
+              "applyPolicies": "[\"stuart-mc-token-exchange\"]"
+            }
+          },
+          {
+            "id": "acf5dd9b-d247-4cf7-bfff-f8e5ef88e669",
+            "name": "manage.permission.client.9ff3f2e4-5ef6-43c8-bacc-8f94ab2b6a42",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.9ff3f2e4-5ef6-43c8-bacc-8f94ab2b6a42\"]",
+              "scopes": "[\"manage\"]"
+            }
+          },
+          {
+            "id": "42e209a6-5772-4d52-b54c-9c0e1dcdbc90",
+            "name": "configure.permission.client.9ff3f2e4-5ef6-43c8-bacc-8f94ab2b6a42",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.9ff3f2e4-5ef6-43c8-bacc-8f94ab2b6a42\"]",
+              "scopes": "[\"configure\"]"
+            }
+          },
+          {
+            "id": "bcc1c12b-ea4a-45e5-94c6-2c479beec44d",
+            "name": "view.permission.client.9ff3f2e4-5ef6-43c8-bacc-8f94ab2b6a42",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.9ff3f2e4-5ef6-43c8-bacc-8f94ab2b6a42\"]",
+              "scopes": "[\"view\"]"
+            }
+          },
+          {
+            "id": "7e2f9ba3-dcce-4a7c-872f-666449f02f40",
+            "name": "map-roles.permission.client.9ff3f2e4-5ef6-43c8-bacc-8f94ab2b6a42",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.9ff3f2e4-5ef6-43c8-bacc-8f94ab2b6a42\"]",
+              "scopes": "[\"map-roles\"]"
+            }
+          },
+          {
+            "id": "3e8ac516-c91a-4fea-9cc6-c267d522fe79",
+            "name": "map-roles-client-scope.permission.client.9ff3f2e4-5ef6-43c8-bacc-8f94ab2b6a42",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.9ff3f2e4-5ef6-43c8-bacc-8f94ab2b6a42\"]",
+              "scopes": "[\"map-roles-client-scope\"]"
+            }
+          },
+          {
+            "id": "da87c8f9-e2bd-4111-8aa5-9167adbe6049",
+            "name": "map-roles-composite.permission.client.9ff3f2e4-5ef6-43c8-bacc-8f94ab2b6a42",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.9ff3f2e4-5ef6-43c8-bacc-8f94ab2b6a42\"]",
+              "scopes": "[\"map-roles-composite\"]"
+            }
+          },
+          {
+            "id": "2b4f7e81-1e86-4204-bd5d-f48888f35dab",
+            "name": "token-exchange.permission.client.9ff3f2e4-5ef6-43c8-bacc-8f94ab2b6a42",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.9ff3f2e4-5ef6-43c8-bacc-8f94ab2b6a42\"]",
+              "scopes": "[\"token-exchange\"]",
+              "applyPolicies": "[\"stuart-mc-token-exchange\"]"
+            }
+          },
+          {
+            "id": "0a848cfd-4a2c-4456-a539-8c1c3414c2c5",
+            "name": "manage.permission.client.d60ee94d-207f-4fef-94d5-75d80649951a",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.d60ee94d-207f-4fef-94d5-75d80649951a\"]",
+              "scopes": "[\"manage\"]"
+            }
+          },
+          {
+            "id": "929ed1ee-044e-4fbd-b86d-79d122143537",
+            "name": "configure.permission.client.d60ee94d-207f-4fef-94d5-75d80649951a",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.d60ee94d-207f-4fef-94d5-75d80649951a\"]",
+              "scopes": "[\"configure\"]"
+            }
+          },
+          {
+            "id": "f61febe1-3b40-42bb-a8f8-0d724bc8e005",
+            "name": "view.permission.client.d60ee94d-207f-4fef-94d5-75d80649951a",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.d60ee94d-207f-4fef-94d5-75d80649951a\"]",
+              "scopes": "[\"view\"]"
+            }
+          },
+          {
+            "id": "bd887031-a861-4f81-98ba-53ab8b9c80bd",
+            "name": "map-roles.permission.client.d60ee94d-207f-4fef-94d5-75d80649951a",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.d60ee94d-207f-4fef-94d5-75d80649951a\"]",
+              "scopes": "[\"map-roles\"]"
+            }
+          },
+          {
+            "id": "b943acc7-eb37-45c8-83e3-b40b97ed9def",
+            "name": "map-roles-client-scope.permission.client.d60ee94d-207f-4fef-94d5-75d80649951a",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.d60ee94d-207f-4fef-94d5-75d80649951a\"]",
+              "scopes": "[\"map-roles-client-scope\"]"
+            }
+          },
+          {
+            "id": "557c71ae-660d-4bb1-928c-6913edd29f72",
+            "name": "map-roles-composite.permission.client.d60ee94d-207f-4fef-94d5-75d80649951a",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.d60ee94d-207f-4fef-94d5-75d80649951a\"]",
+              "scopes": "[\"map-roles-composite\"]"
+            }
+          },
+          {
+            "id": "918c36a3-3e0a-4321-b59a-2c751ec3d794",
+            "name": "token-exchange.permission.client.d60ee94d-207f-4fef-94d5-75d80649951a",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.d60ee94d-207f-4fef-94d5-75d80649951a\"]",
+              "scopes": "[\"token-exchange\"]",
+              "applyPolicies": "[\"stuart-mc-token-exchange\"]"
+            }
+          },
+          {
+            "id": "6ed44efe-53d6-4296-a174-7e3c103d842f",
+            "name": "manage.permission.client.6b1c153e-b80a-4889-9851-98a34bef59c8",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.6b1c153e-b80a-4889-9851-98a34bef59c8\"]",
+              "scopes": "[\"manage\"]"
+            }
+          },
+          {
+            "id": "993a3394-4016-4a5c-943e-b88f53c9e1d9",
+            "name": "configure.permission.client.6b1c153e-b80a-4889-9851-98a34bef59c8",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.6b1c153e-b80a-4889-9851-98a34bef59c8\"]",
+              "scopes": "[\"configure\"]"
+            }
+          },
+          {
+            "id": "fabe84e5-c8c6-4d27-ad7d-f6511a255507",
+            "name": "view.permission.client.6b1c153e-b80a-4889-9851-98a34bef59c8",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.6b1c153e-b80a-4889-9851-98a34bef59c8\"]",
+              "scopes": "[\"view\"]"
+            }
+          },
+          {
+            "id": "ad2fe3a4-3f05-40ac-927e-f4fca717dfcc",
+            "name": "map-roles.permission.client.6b1c153e-b80a-4889-9851-98a34bef59c8",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.6b1c153e-b80a-4889-9851-98a34bef59c8\"]",
+              "scopes": "[\"map-roles\"]"
+            }
+          },
+          {
+            "id": "f6c08070-8efc-4235-9b0b-377441852560",
+            "name": "map-roles-client-scope.permission.client.6b1c153e-b80a-4889-9851-98a34bef59c8",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.6b1c153e-b80a-4889-9851-98a34bef59c8\"]",
+              "scopes": "[\"map-roles-client-scope\"]"
+            }
+          },
+          {
+            "id": "61dc9c56-7b67-4791-8012-a0ccdd61f80f",
+            "name": "map-roles-composite.permission.client.6b1c153e-b80a-4889-9851-98a34bef59c8",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.6b1c153e-b80a-4889-9851-98a34bef59c8\"]",
+              "scopes": "[\"map-roles-composite\"]"
+            }
+          },
+          {
+            "id": "394f376e-3e35-480a-a5a6-16e7b12ee71e",
+            "name": "token-exchange.permission.client.6b1c153e-b80a-4889-9851-98a34bef59c8",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.6b1c153e-b80a-4889-9851-98a34bef59c8\"]",
+              "scopes": "[\"token-exchange\"]",
+              "applyPolicies": "[\"stuart-mc-token-exchange\"]"
+            }
+          },
+          {
+            "id": "73b03d56-4c53-4be8-b9a1-6bcc01f2df8d",
+            "name": "manage.permission.client.36570e43-8272-426a-998f-a528a23a6d23",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.36570e43-8272-426a-998f-a528a23a6d23\"]",
+              "scopes": "[\"manage\"]"
+            }
+          },
+          {
+            "id": "2d0a2876-b575-4d49-9a0f-e86e3fb7c9b4",
+            "name": "configure.permission.client.36570e43-8272-426a-998f-a528a23a6d23",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.36570e43-8272-426a-998f-a528a23a6d23\"]",
+              "scopes": "[\"configure\"]"
+            }
+          },
+          {
+            "id": "8adce83e-b4ad-4ff1-89c3-212fff1f4b66",
+            "name": "view.permission.client.36570e43-8272-426a-998f-a528a23a6d23",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.36570e43-8272-426a-998f-a528a23a6d23\"]",
+              "scopes": "[\"view\"]"
+            }
+          },
+          {
+            "id": "6535f6ac-aa52-407e-a811-3b4b9653126d",
+            "name": "map-roles.permission.client.36570e43-8272-426a-998f-a528a23a6d23",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.36570e43-8272-426a-998f-a528a23a6d23\"]",
+              "scopes": "[\"map-roles\"]"
+            }
+          },
+          {
+            "id": "d2b6bd81-911b-4be4-ab3e-9b314e833690",
+            "name": "map-roles-client-scope.permission.client.36570e43-8272-426a-998f-a528a23a6d23",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.36570e43-8272-426a-998f-a528a23a6d23\"]",
+              "scopes": "[\"map-roles-client-scope\"]"
+            }
+          },
+          {
+            "id": "bfd76f1d-0635-47a9-8ea9-3bb00254df20",
+            "name": "map-roles-composite.permission.client.36570e43-8272-426a-998f-a528a23a6d23",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.36570e43-8272-426a-998f-a528a23a6d23\"]",
+              "scopes": "[\"map-roles-composite\"]"
+            }
+          },
+          {
+            "id": "b3ea1af1-abfd-4d7f-a444-8b965d242cc2",
+            "name": "token-exchange.permission.client.36570e43-8272-426a-998f-a528a23a6d23",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.36570e43-8272-426a-998f-a528a23a6d23\"]",
+              "scopes": "[\"token-exchange\"]",
+              "applyPolicies": "[\"stuart-mc-token-exchange\"]"
+            }
+          },
+          {
+            "id": "76a074e3-5915-4445-bd0b-2894b22bf5ef",
+            "name": "manage.permission.client.d8012a59-8fe5-41c2-b3c9-5dc7907889f3",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.d8012a59-8fe5-41c2-b3c9-5dc7907889f3\"]",
+              "scopes": "[\"manage\"]"
+            }
+          },
+          {
+            "id": "f25a553a-3dd9-4b3b-b539-83fc8af3fe4a",
+            "name": "configure.permission.client.d8012a59-8fe5-41c2-b3c9-5dc7907889f3",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.d8012a59-8fe5-41c2-b3c9-5dc7907889f3\"]",
+              "scopes": "[\"configure\"]"
+            }
+          },
+          {
+            "id": "12a85e50-0c9c-4439-a202-a91d43636391",
+            "name": "view.permission.client.d8012a59-8fe5-41c2-b3c9-5dc7907889f3",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.d8012a59-8fe5-41c2-b3c9-5dc7907889f3\"]",
+              "scopes": "[\"view\"]"
+            }
+          },
+          {
+            "id": "e1f973f0-b031-4466-b5c2-1d09152ef9d7",
+            "name": "map-roles.permission.client.d8012a59-8fe5-41c2-b3c9-5dc7907889f3",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.d8012a59-8fe5-41c2-b3c9-5dc7907889f3\"]",
+              "scopes": "[\"map-roles\"]"
+            }
+          },
+          {
+            "id": "011cc431-5fd4-4084-aae4-af11f56fecc3",
+            "name": "map-roles-client-scope.permission.client.d8012a59-8fe5-41c2-b3c9-5dc7907889f3",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.d8012a59-8fe5-41c2-b3c9-5dc7907889f3\"]",
+              "scopes": "[\"map-roles-client-scope\"]"
+            }
+          },
+          {
+            "id": "5e1e3ff2-404c-4c5d-9a28-c847eb79463c",
+            "name": "map-roles-composite.permission.client.d8012a59-8fe5-41c2-b3c9-5dc7907889f3",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.d8012a59-8fe5-41c2-b3c9-5dc7907889f3\"]",
+              "scopes": "[\"map-roles-composite\"]"
+            }
+          },
+          {
+            "id": "4b5fdd1c-046f-422d-a4a6-0ac9dbd26017",
+            "name": "token-exchange.permission.client.d8012a59-8fe5-41c2-b3c9-5dc7907889f3",
+            "type": "scope",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "resources": "[\"client.resource.d8012a59-8fe5-41c2-b3c9-5dc7907889f3\"]",
+              "scopes": "[\"token-exchange\"]",
+              "applyPolicies": "[\"stuart-mc-token-exchange\"]"
+            }
+          }
+        ],
+        "scopes": [
+          {
+            "id": "a48742f0-687d-471c-8940-ac4361fb45c4",
+            "name": "manage-membership"
+          },
+          {
+            "id": "9eb4695d-6b4c-4fe8-b4ea-62c57ddc82f3",
+            "name": "view-members"
+          },
+          {
+            "id": "e1386b5c-8d43-492d-82d5-6a9f61c24ebb",
+            "name": "manage-members"
+          },
+          {
+            "id": "3ccf80df-e655-4754-ab7a-d57fe42cd076",
+            "name": "token-exchange"
+          },
+          {
+            "id": "d61c61e7-9def-468c-9298-df82e01ccab2",
+            "name": "configure"
+          },
+          {
+            "id": "3e1ad097-5884-4034-9648-59b8c8ce5f03",
+            "name": "map-roles-composite"
+          },
+          {
+            "id": "d505d382-7c40-4644-adce-3dc092bf0e9e",
+            "name": "map-roles-client-scope"
+          },
+          {
+            "id": "34ed9a73-42e7-4da3-b576-425cd7acf1b2",
+            "name": "map-roles"
+          },
+          {
+            "id": "833afd9c-cc82-4804-ba65-b3e5e7b38e56",
+            "name": "view"
+          },
+          {
+            "id": "de0ea592-449a-44d6-9bc3-7103080b1f57",
+            "name": "manage"
+          }
+        ],
+        "decisionStrategy": "UNANIMOUS"
+      }
+    },
+    {
+      "id": "82b9d6e7-79d6-47c6-8184-19edda65e9ba",
+      "clientId": "ship6-test",
+      "rootUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://example.com"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "access.token.lifespan": "2592000",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "22ddefc8-32b7-4dbf-8c1c-4094325919a6",
+          "name": "srt:client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "61c47cdb-2ffb-47b7-b43e-3d9f16520f30",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "89bf63f8-0de9-4855-8656-f184b18482ae",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ee375500-a026-4e94-a7e5-245ff765e104",
+          "name": "srt:zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "5e5db5d9-33b3-4cd6-80e4-26cfc0cf17ee",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"ephemeral\",\"development\", \"beta\", \"qa\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "c22dd0b0-5727-494f-be34-2919c48f8f9a",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"earningQuote\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "57d5567c-439b-42f3-92f5-b986e0c23ad7",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c25e4b76-729b-46e1-8c15-e811f6e5557d",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"delivery\", \"deliveries\", \"driver\", \"drivers\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "7b912b4d-653a-490f-a8e7-e985918a66b6",
+          "name": "srt_fleet_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:fleet_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "16ee6273-1e99-4edd-8308-a9bc9004dd7b",
+          "name": "srt:features",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"earningQuotes\", \"driverEarnings\", \"workLog\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:features",
+            "jsonType.label": "JSON"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "588b64ef-0a5b-4c9a-ab75-4c7f2e971d23",
+      "clientId": "solutions-integrations-middleware",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost:3000/auth/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "b6012287-fdf5-41c4-be31-3bc669e46292",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "69ce5741-fabc-4141-8db3-76f1e696f933",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "44b62f85-4b48-49e2-9222-bb51799f005e",
+          "name": "srt:client_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"0\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_id",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "689a3f83-32f0-462e-8ca4-b0715b98467e",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"beta\", \"qa\", \"development\", \"ephemeral\", \"sandbox\", \"test\", \"production\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "3294abef-853b-4c1a-9b41-e16d656626d6",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"packageSearch\", \"deleteSavedSearches\", \"schedulePackage\", \"updatePackageReference\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "b2fb2a18-302f-4a2c-ba32-5e1a1cf1dfa1",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"whoami\", \"calculateDistanceAndDuration\",\"geocode\", \"drivers\", \"reverseGeocode\", \"invitableDrivers\", \"packages\", \"packageSearch\", \"deliveries\", \"delivery\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "a377ebce-3fe6-43e5-8236-595bedf412a9",
+          "name": "srt:flags",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"pii\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:flags",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "ecaded51-a616-4734-8ba9-ebe0bb733548",
+          "name": "srt:zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "1e45be21-099e-40a3-92a1-c5755a18b5f7",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c44e2671-b264-4dc1-9a6e-d3a9a5b52959",
+          "name": "srt:client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "jsonType.label": "JSON"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt",
+        "graphql"
+      ]
+    },
+    {
+      "id": "03016061-b6ee-4cd6-8e02-c08bf727a653",
+      "clientId": "solutions-closing-tool",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://127.0.0.1:9999/oauth/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "0e4abc1a-bc69-4045-b789-dbf4ef643468",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"beta\", \"qa\", \"development\", \"ephemeral\", \"sandbox\", \"test\", \"production\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "91e98135-f4e8-4090-91a3-c9c23b38cf6e",
+          "name": "srt:zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "cec38f4c-3ccf-4400-8df6-0b4d0d0c3aa9",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "4e7ee14e-c1cd-4a07-b696-6744ae45b580",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "7d6a573f-2ad6-43ee-a367-8cf1d47ba917",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"whoami\", \"calculateDistanceAndDuration\", \"geocode\", \"zones\", \"preOrderETA\", \"packages\", \"deliveries\", \"drivers\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "0dce4243-4ed3-437f-aaed-2491fc9e7ccc",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "6081d6e7-b135-41ac-8e8e-cd17d30b0c94",
+      "clientId": "devops-ephemeral",
+      "name": "",
+      "description": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://127.0.0.1:9999"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "access.token.lifespan": "3600",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "0560265d-52e0-4489-bd9d-2b81bfdbf134",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "a3b04063-8128-4da5-802b-27d694c0ea2d",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "a06fc4a6-c8ba-4aed-9e92-82d275f98463",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "b9421fcb-49fe-47ef-8f4e-377e050b757c",
+      "clientId": "app-rasa-beta",
+      "name": "Rasa Beta",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://dkang.ngrok.io/webhooks/stuart_sso/webhook*",
+        "https://rasa.beta.internal.stuart.com/webhooks/stuart_sso/webhook*",
+        "http://gemma-stuart.ngrok.io/webhooks/stuart_sso/webhook*",
+        "https://rasa.beta.stuart.com/webhooks/stuart_sso/webhook*",
+        "http://127.0.0.1:9999/oauth/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "access.token.lifespan": "300",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "login_theme": "stuartdefault",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "7a6fbf7c-538a-4dc6-bd56-dbccbd5e0197",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "66d7fee4-6e44-4389-a0ab-2371881c093f",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"packages\", \"deliveries\",\"tasks\",\"whoami\",\"delivery\",\"driver\",\"businessRules\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "e6f2bdf7-40ab-4c75-ae95-aefdd7ea2e1f",
+          "name": "srt:flags",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"pii\", \"invisible\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:flags",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "b614ea7e-734d-4613-bea1-2cb3db46d146",
+          "name": "srt:client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "a906d0c3-59d5-4afd-b9d8-14c51d34848f",
+          "name": "srt:zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "78124d23-6157-47c1-8b59-25a0834ba06b",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"beta\",\"sandbox\",\"development\",\"test\",\"qa\", \"ephemeral\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "4d4f0a9b-74de-4097-a34b-9aa93d8dcdd9",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "38ff00d4-93c1-4063-8ba7-fd127e6db359",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"package\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "0a68c883-bae5-4b9f-a77b-e771c55bac8e",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ace267cb-416d-4377-87e7-ec34356aa80f",
+          "name": "srt:fleet_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:fleet_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "3fd274a0-5603-46eb-805b-9e8f5dd47d93",
+          "name": "srt:features",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"dma\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:features",
+            "jsonType.label": "JSON"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "role_list",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt",
+        "graphql"
+      ]
+    },
+    {
+      "id": "5dd22b80-2676-4ebf-9925-413fb6bad3b9",
+      "clientId": "solutions-development",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost:3000/auth/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "access.token.lifespan": "86400",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "6faa5fdd-76ed-4e87-ac54-2f8899ba0f4f",
+          "name": "srt:fleet_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:fleet_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "0361bb39-e71f-4520-b6fa-2e9a79b0d827",
+          "name": "srt:zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "eff0cc6d-5020-405a-a8aa-a5b4da1b66c3",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"whoami\", \"calculateDistanceAndDuration\",\"geocode\", \"drivers\", \"reverseGeocode\", \"invitableDrivers\", \"packages\", \"packageSearch\", \"fixGeocode\", \"deliverySlots\", \"zone\", \"preOrderETA\", \"fleets\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "1e0812b6-e147-4e7f-b229-d7e0a0f628c8",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"beta\", \"qa\", \"development\", \"ephemeral\", \"sandbox\", \"test\", \"production\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "7a6953d7-e244-4017-a712-93d20e7eee48",
+          "name": "srt:client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "a6526f5a-5530-4b60-a4f3-acdd4de4d71e",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "005f6244-1542-464f-a5d4-c367ab7eb205",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"packageSearch\", \"deleteSavedSearches\", \"schedulePackage\", \"updatePackageReference\", \"fixGeocode\", \"applyEarningsMultipliers\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "9dce9019-4f8a-4bbb-b707-b7d5554acb9e",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d452bb3e-20cd-4ae9-a623-9439072bbe5d",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt",
+        "graphql"
+      ],
+      "authorizationSettings": {
+        "allowRemoteResourceManagement": true,
+        "policyEnforcementMode": "ENFORCING",
+        "resources": [
+          {
+            "name": "Default Resource",
+            "type": "urn:solutions-development:resources:default",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "bded2f1d-d580-4717-b03e-6f0c381859eb",
+            "uris": [
+              "/*"
+            ]
+          }
+        ],
+        "policies": [
+          {
+            "id": "2b9be81a-59b3-4927-a26c-2b4043f92aae",
+            "name": "Default Policy",
+            "description": "A policy that grants access only for users within this realm",
+            "type": "js",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "code": "// by default, grants any permission associated with this policy\n$evaluation.grant();\n"
+            }
+          },
+          {
+            "id": "b6a51f02-9005-4bc4-b159-4bfe5605c0a9",
+            "name": "Default Permission",
+            "description": "A permission that applies to the default resource type",
+            "type": "resource",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "defaultResourceType": "urn:solutions-development:resources:default",
+              "applyPolicies": "[\"Default Policy\"]"
+            }
+          }
+        ],
+        "scopes": [],
+        "decisionStrategy": "AFFIRMATIVE"
+      }
+    },
+    {
+      "id": "60d21c30-8e5a-4a24-b0e4-175ae1ead774",
+      "clientId": "solutions-fleet-injection",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost/"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "login_theme": "keycloak",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "bc010b2b-d174-4fb9-b960-22df1960f8a1",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "0b7967fd-54a1-47a0-8be8-5c7a43f4f2dc",
+          "name": "srt:client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "a82bbf4c-a35c-43ae-99f4-b1517303e90b",
+          "name": "srt:fleet_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:fleet_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "0ef3b07a-66d7-4f8a-9119-14a8766151e3",
+          "name": "srt:client_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "\"0\"",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_id",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "bab26857-c34c-486e-b3fc-3ee1a066a7ed",
+          "name": "srt:subscriptions",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:subscriptions",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "358da647-806b-4c36-8a05-f95a04eba3a4",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"beta\", \"qa\", \"development\", \"ephemeral\", \"sandbox\", \"test\", \"production\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "58f95748-ebb9-45b2-a9cc-2fd8008eb874",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "5afda4b6-2a3a-4dff-a998-75b096837454",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "a0a8b733-4256-45c6-be2c-0a3750981ab0",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d995dd60-b0a8-4cd9-a473-457b39055973",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"drivers\", \"zones\", \"zone\", \"driver\", \"geocode\", \"reverseGeocode\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "e51f05ef-538a-40ae-8a5d-288ae8b29f17",
+          "name": "srt:zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "JSON"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ],
+      "authorizationSettings": {
+        "allowRemoteResourceManagement": true,
+        "policyEnforcementMode": "ENFORCING",
+        "resources": [
+          {
+            "name": "Default Resource",
+            "type": "urn:solutions-fleet-injection:resources:default",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "fb475c95-7cc5-4c72-9099-3ea60ed4a8d6",
+            "uris": [
+              "/*"
+            ]
+          }
+        ],
+        "policies": [
+          {
+            "id": "d9eb7ea3-14c9-4aef-8a09-e4102d1d09c4",
+            "name": "Default Policy",
+            "description": "A policy that grants access only for users within this realm",
+            "type": "js",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "code": "// by default, grants any permission associated with this policy\n$evaluation.grant();\n"
+            }
+          },
+          {
+            "id": "dc20251e-7408-4d37-b792-db083f5e0feb",
+            "name": "Default Permission",
+            "description": "A permission that applies to the default resource type",
+            "type": "resource",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "defaultResourceType": "urn:solutions-fleet-injection:resources:default",
+              "applyPolicies": "[\"Default Policy\"]"
+            }
+          }
+        ],
+        "scopes": [],
+        "decisionStrategy": "UNANIMOUS"
+      }
+    },
+    {
+      "id": "6b1c153e-b80a-4889-9851-98a34bef59c8",
+      "clientId": "pulse",
+      "name": "Pulse",
+      "rootUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "https://flow.beta.stuart.com/oauth/callback/apps",
+        "https://flow.stuart.com/oauth/callback/apps",
+        "http://localhost:3000/oauth/callback/apps",
+        "http://127.0.0.1:9999/oauth/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "c3b14a34-f6b8-4cba-b586-1ae966233f37",
+          "name": "srt:zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "663024d5-fa64-4316-b76e-e080644e4025",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"whoami\", \"zone\", \"zones\", \"drivers\", \"driver\", \"client\", \"clients\", \"fleets\",\"packages\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "eeaa80c5-744c-40fb-9515-7085ae700ec2",
+          "name": "srt:features",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"dma\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:features",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "67a97c45-2f40-4ffe-b4e8-9a8c2a0905a0",
+          "name": "srt:fleet_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:fleet_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "fb6b107f-8dd6-40b7-ad66-5dafaf331331",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d73fae86-05b7-473b-9032-33a1c3750ad6",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "12abdd48-319d-48b9-89f2-4d325830bf6e",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "9a63f131-2228-42f9-9608-634879f96392",
+          "name": "srt:client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "e14baf3e-5293-4e00-ad25-aede72f9a224",
+          "name": "srt:flags",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"pii\", \"invisible\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:flags",
+            "jsonType.label": "JSON"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "graphql",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ],
+      "authorizationSettings": {
+        "allowRemoteResourceManagement": true,
+        "policyEnforcementMode": "ENFORCING",
+        "resources": [
+          {
+            "name": "Default Resource",
+            "type": "urn:pulse:resources:default",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "6d8aba76-c31d-48bf-85eb-c85d82e6e422",
+            "uris": [
+              "/*"
+            ]
+          }
+        ],
+        "policies": [
+          {
+            "id": "7458049c-88eb-4781-80b6-59f0a1859a37",
+            "name": "Default Policy",
+            "description": "A policy that grants access only for users within this realm",
+            "type": "js",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "code": "// by default, grants any permission associated with this policy\n$evaluation.grant();\n"
+            }
+          },
+          {
+            "id": "2d16c257-abe3-4538-a349-78a8b8a1c668",
+            "name": "Default Permission",
+            "description": "A permission that applies to the default resource type",
+            "type": "resource",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "defaultResourceType": "urn:pulse:resources:default",
+              "applyPolicies": "[\"Default Policy\"]"
+            }
+          }
+        ],
+        "scopes": [],
+        "decisionStrategy": "UNANIMOUS"
+      }
+    },
+    {
+      "id": "b5b26c13-8c70-4565-b478-a162f259582e",
+      "clientId": "statuspage.io",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "saml",
+      "attributes": {
+        "saml.signing.certificate": "MIICqTCCAZECBgF6jDlYqjANBgkqhkiG9w0BAQsFADAYMRYwFAYDVQQDDA1zdGF0dXNwYWdlLmlvMB4XDTIxMDcwOTE3MDE0NloXDTMxMDcwOTE3MDMyNlowGDEWMBQGA1UEAwwNc3RhdHVzcGFnZS5pbzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMdW/b3cm0myLAKZN/yPZsGiNkA1fPOarxiY7WT3cnO06G5WSab4aL/G+CDSGYvqKNqqWSIjxSPRon8SxUGs/wEJy6QZQjjaq6MWgnwLRfnTvPZ+YC+Sn6amkLWwWfmqrGoRsl/5CSSKna3wCFEOu22xy3xCeDzUYttJ7QtwHWb4n57beJB1Np2MQsnUyLN0/af1JK2CqT3govYjlyDvtqMqfSqNZzrJJZcw88/F2I3SHdZ8RSHk/Oxr30ErYVK3ZUqXt0vZ+W6xee8u+BAbJVcfz4qrbvmakRs/2MhUPO7LE5S28idqHbwVEaPfga4nvk5UO1yEkYidImsODTog0R0CAwEAATANBgkqhkiG9w0BAQsFAAOCAQEApXof17bsOH6piYTNfF+DildUiZqVplCJiIpcXX+z4Lj4iAExIGlWNTT/44fvdPNaReZo3jWU+X0epnyv/7yWF9FsLVtn4UkTfuoNoEYcy3J7sLhRP2oDKvRzV6HxMh6F8+6EEuH1WrxwA1/APXw7Bpb8bGt1pgyiHfPg55KLDSHrdKhQXu9nUMVGKhubGfIr5ux74B+8i+GeRqMn9WDRZJazMOrRcjIGPj3gl12bdpm4lrMrQOtra1iRyJIeYcuTBTQVeh1IFT4igc09oLAiLuVCL69bvgl4bPGDduIFmc3fVBRYAfqV3YAakrNwYQzzy3+knvUqzCMM0Gp2QwstyQ==",
+        "saml.signature.algorithm": "RSA_SHA256",
+        "saml.force.post.binding": "true",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "true",
+        "saml.authnstatement": "true",
+        "saml_name_id_format": "username",
+        "saml.signing.private.key": "MIIEowIBAAKCAQEAx1b9vdybSbIsApk3/I9mwaI2QDV885qvGJjtZPdyc7ToblZJpvhov8b4INIZi+oo2qpZIiPFI9GifxLFQaz/AQnLpBlCONqroxaCfAtF+dO89n5gL5KfpqaQtbBZ+aqsahGyX/kJJIqdrfAIUQ67bbHLfEJ4PNRi20ntC3AdZvifntt4kHU2nYxCydTIs3T9p/UkrYKpPeCi9iOXIO+2oyp9Ko1nOskllzDzz8XYjdId1nxFIeT87GvfQSthUrdlSpe3S9n5brF57y74EBslVx/Piqtu+ZqRGz/YyFQ87ssTlLbyJ2odvBURo9+Brie+TlQ7XISRiJ0iaw4NOiDRHQIDAQABAoIBAQDCNJ1HIStlNCGucmnaNDePRKMIEVRn3PbjxvHZoT4vPjwIayacdn1PAeDx0N80sfAVgUsPeLvy9qUSmk31ez6BW3K7sCQVUe1QGXkMssr852281EiPcJD8AmEPsf0mwUHyoMUgvXZL1IRkVmsz1V+DMmml6PhNgznAnRhFQXhTvQGjc7W9WtDTY4b0O03WJ7CiGzQ9UjgarXRTwCZKkdETlIOjXAxxk3cWkhtHWwnkbwbeLBqFBfz62cmRNpqcsb63xvq5zaW2QHbYqNCmNsOAM2besVQNN0qM3dxYQpnJIQwQAx9PwApe+KznPVeENX58Vl9Ih7Qag7Nr4v3RG5odAoGBAPaJXev9q+k4U22kWlmHJjdIw74wxFd4ifknmVLO58Tpjzf4BA3BEgMmj3S0wOAJnh+uEVd0WtHhtYFwuIxhaZLUAMqg3QFls52sNW3dhcpYCYaJOQbaF0JDvwjrf+shQn2K0EhsTsLWM9zsp7DALnLoPRAuucmuL/RVXtEyw2tDAoGBAM791lRuw1wNnCEnmixB4m+l5oOnbBuVWua6zsGc+K6ANnatvIfzWs9fMFy389E61px8lJNvvGHxq5NIzs88ZlWVH2/CEbIbRimfp6AVyjKAQ6PQxnhX20KrH/RgU+2uAgD4gdsamEDWIFju+PwgE3MPoIe/6rvIrGKpk2bp3pwfAoGAfGzPzi70+HvI/2kXgF/JVdWPlQmfzlWzrN/jbfum1aba9XBi+14Z7SUk+c3QGkJAX9TGQ9EhlRPJO07clV0En2oIDDwrzmy5vjYPsSdAQuMzy4auFVs0qejvHV1d7hmXKS1J+YNQLN1Wx4VZDMexqaS0TNqIQdV7tmDvvb1VC2kCgYA+9MukoI/Axs7u8pmczmktphrnfhuOhC3CsZzDHJgykwJ9tDf8bZL4Ma6G9NgukiPGMsoJ0dlNPPD/egyU0X0amKGYH0G8lzkO3eVg9l+qXoK0J4LGBYrFy0CL1mSQjPVFEFCGsJ8QUVBDXGPUY3km7ODZiRC/DrkHxSX1DjrL5wKBgCPdASkM+9O4R7e9LyIiqVGAgawXZjeYWQSXysmkBSIO+Ud8nMp7yN3puodRyhyzK7keuOtTTJQVoTXEUV87+I2TiUXauiHHKr46ed3TTFp4HYV/x0rJG7AVMQq4JcL9KyU0Xlg2r10XyonT+NzezWj+RI/YJdkw4dIN0u7DHny5",
+        "saml.server.signature": "true",
+        "saml_signature_canonicalization_method": "http://www.w3.org/2001/10/xml-exc-c14n#"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "14db51d3-cdd2-42a8-914c-d4f870b6d468",
+      "clientId": "package-incentives-production",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost:3000/"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "5ef53d2d-7816-44d7-af9b-1feaa855d546",
+          "name": "srt:client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "a974272f-ea4e-48b3-8c14-f2352856c4c6",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ec88c35a-5ffe-4d6f-b929-ee6863d0e826",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "0c109ecb-927b-4ea8-8a1f-40a0be20aedf",
+          "name": "srt:zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "d1b64968-6262-41f7-aa63-6c8be7b61fdc",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"package\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "a283b32e-0308-4a47-8d9b-85ce6a897d61",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"production\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "1f0fb98a-f1b9-4c3b-ae96-f93f7f4c6ff2",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"packages\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "370d729a-6b92-433c-a5ea-f09a7182df16",
+          "name": "srt:features",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"packageIncentives\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:features",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "6d313af5-9412-4c79-849c-6e278ec539ec",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "role_list"
+      ],
+      "optionalClientScopes": []
+    },
+    {
+      "id": "de6c431f-8a0c-4f69-97bb-857d488a4d8f",
+      "clientId": "federation-proxy-service-discovery",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "https://localhost:9999"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "0b39f7ab-c6e2-4c66-af71-e1559c41a333",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"qa\", \"development\", \"production\", \"sandbox\", \"ephemeral\", \"beta\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "f6976402-0a5d-491b-871f-da54222fc228",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "56476631-1ae2-40a9-8769-0ec14032eabb",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "70e7fbb5-ae10-4a57-bc80-128c9f62a6e3",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "10060781-2ac4-4208-825e-1ca460541fab",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"_service\", \"whoami\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "graphql",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ],
+      "authorizationSettings": {
+        "allowRemoteResourceManagement": true,
+        "policyEnforcementMode": "ENFORCING",
+        "resources": [
+          {
+            "name": "Default Resource",
+            "type": "urn:federation-proxy-service-discovery:resources:default",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "35780832-82f1-412e-a512-b59786db2267",
+            "uris": [
+              "/*"
+            ]
+          }
+        ],
+        "policies": [
+          {
+            "id": "4fa790c6-5147-4454-9919-3d9d7d7da338",
+            "name": "Default Policy",
+            "description": "A policy that grants access only for users within this realm",
+            "type": "js",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "code": "// by default, grants any permission associated with this policy\n$evaluation.grant();\n"
+            }
+          },
+          {
+            "id": "68654366-084e-4af8-8eda-f15a1f9f8d1a",
+            "name": "Default Permission",
+            "description": "A permission that applies to the default resource type",
+            "type": "resource",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "defaultResourceType": "urn:federation-proxy-service-discovery:resources:default",
+              "applyPolicies": "[\"Default Policy\"]"
+            }
+          }
+        ],
+        "scopes": [],
+        "decisionStrategy": "UNANIMOUS"
+      }
+    },
+    {
+      "id": "aaa6ce5f-85a8-4938-97ab-60e3db2fe5b8",
+      "clientId": "solutions-rule-engine",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost:3000/auth/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "3f487826-a07f-46a5-b381-76f77ed260b4",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"beta\", \"qa\", \"development\", \"ephemeral\", \"sandbox\", \"test\", \"production\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "70206e94-a3b1-488a-8dab-0813b4ddff87",
+          "name": "srt:features",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"packageIncentives\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:features",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "1c5cee27-afd3-4aa4-9053-309f5b4908c8",
+          "name": "srt:flags",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"pii\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:flags",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "0e1f440f-9959-4508-8472-e0cd382fd9f3",
+          "name": "srt:client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "afde7284-e398-4e4b-b0f4-955ef306be66",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "4e4d0136-9b1b-4c44-bc04-313febd00dae",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"packages\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "0c49ebb2-c71f-40fa-b81e-7fca44886763",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "63785c05-a9b2-4b39-ba62-eee4f4db5093",
+          "name": "srt:zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "af147467-70a6-4ff8-8472-fe852fdbe602",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"package\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "498c222c-418b-42d0-b222-6c2963528295",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "497f85e0-7e42-4f46-87a8-a5d631857248",
+          "name": "srt:client_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"0\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_id",
+            "jsonType.label": "JSON"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt",
+        "graphql"
+      ]
+    },
+    {
+      "id": "dce1ba61-ed7c-4756-a537-44ed9bb994de",
+      "clientId": "fr-bizops",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost:3000/"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "3237cbd4-7317-4f92-be18-8f8f5f87437b",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "b564a6f7-195e-4e62-a683-8b0f22fa2fba",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"package\", \"schedulePackage\", \"applyEarningsMultipliers\"]",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "c95fb802-f0aa-4d2c-b87f-9bae08755b70",
+          "name": "srt:zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "fe757909-930c-4ec8-89b4-2ef79358b35e",
+          "name": "srt:client_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_id",
+            "claim.value": "[\"0\"]",
+            "userinfo.token.claim": "false"
+          }
+        },
+        {
+          "id": "acc3bc08-bc15-4f21-b186-d8193647cf49",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d539021f-113d-49ff-983c-fd4c89ff71f8",
+          "name": "str:fleet_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:fleet_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "ae73e2e0-e96d-4221-80e4-5ab14d3f7f11",
+          "name": "srt:features",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"packageIncentivesStandBy\"]",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "srt:features",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "6ce3d81f-aa29-42d9-a71a-7193b6836e7c",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"production\", \"beta\", \"sandbox\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "d4487af7-2f1b-4532-9441-4865ba0dd370",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "9865a1fc-b32e-4489-bc18-c9dcf01bf4c0",
+          "name": "srt:client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "6e634ff0-d58c-4ec4-a9c9-6902a464e545",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"whoami\", \"packageSearches\", \"packageSearchResults\",\"deliveries\", \"delivery\", \"drivers\", \"driver\", \"package\", \"packages\", \"zones\", \"shifts\", \"invitableDrivers\", \"calculateDistanceAndDuration\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt",
+        "graphql"
+      ],
+      "authorizationSettings": {
+        "allowRemoteResourceManagement": true,
+        "policyEnforcementMode": "ENFORCING",
+        "resources": [
+          {
+            "name": "Default Resource",
+            "type": "urn:fr-bizops:resources:default",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "f48b21bb-d8b0-4764-bc81-13be1310c727",
+            "uris": [
+              "/*"
+            ]
+          }
+        ],
+        "policies": [
+          {
+            "id": "91fd9afb-28e4-401d-9408-0d4f2b986f47",
+            "name": "Default Policy",
+            "description": "A policy that grants access only for users within this realm",
+            "type": "js",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "code": "// by default, grants any permission associated with this policy\n$evaluation.grant();\n"
+            }
+          },
+          {
+            "id": "8a050b2e-e96c-4346-8c37-b37cd3bde87e",
+            "name": "Default Permission",
+            "description": "A permission that applies to the default resource type",
+            "type": "resource",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "defaultResourceType": "urn:fr-bizops:resources:default",
+              "applyPolicies": "[\"Default Policy\"]"
+            }
+          }
+        ],
+        "scopes": [],
+        "decisionStrategy": "UNANIMOUS"
+      }
+    },
+    {
+      "id": "766a1a97-93e0-4603-bd9d-128d47e4d306",
+      "clientId": "platform-notification-system",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost:3000/"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "87752ed5-a0e6-45d9-83f9-f4c91dcd187f",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"beta\", \"qa\", \"development\", \"ephemeral\", \"sandbox\", \"test\", \"production\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "031a1bb1-722b-4773-a66c-3e566b6e4e57",
+          "name": "srt:client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "edc5b467-62e4-4073-84b3-0a782ae2ace7",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ab93d43f-5dc9-45ab-9c3a-53a53b78ce87",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"whoami\", \"packageSearch\", \"packageSearchResults\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "f2a0084f-dc93-4932-b2ac-ec0b26715b1d",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ac1b3d7f-295d-47e6-aec2-a77b8ed6d882",
+          "name": "srt:subscriptions",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "jsonType.label": "JSON",
+            "claim.value": "[\"packageSearch\"]",
+            "userinfo.token.claim": "false"
+          }
+        },
+        {
+          "id": "0ad81188-fbde-47d4-bc22-0f44fa05e50f",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "7d993e4a-83ae-4bab-9013-ca396e63479e",
+      "clientId": "security-admin-console",
+      "name": "${client_security-admin-console}",
+      "rootUrl": "${authAdminUrl}",
+      "baseUrl": "/admin/stuart/console/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "/admin/stuart/console/*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "7a48c9fb-7643-432f-907e-5e730f3dc099",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "b27d18e5-79d6-4c84-be11-7f92630e2af8",
+      "clientId": "postman-shared-suite",
+      "rootUrl": "https://example.com/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost:12321",
+        "http://localhost:3000/oauth/callback",
+        "https://example.com/",
+        "https://localhost/",
+        "http://127.0.0.1:9999/oauth/callback",
+        "https://oauth.pstmn.io/v1/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "access.token.lifespan": "28800",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "login_theme": "keycloak",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "50456fe3-f54c-4bad-9d6c-51877b6e8096",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "a0354cc6-7ff9-4399-bf69-f067d41de3e3",
+          "name": "srt:subscriptions",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"packageSearch\", \"packages\", \"packagesScheduled\", \"packagesCanceled\", \"search\", \"vehicleRoutingProblem\",\"driver\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:subscriptions",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "c9eb8b4e-5602-4fc3-86f5-d85f8ee438cb",
+          "name": "srt:flags",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"pii\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:flags",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "cd5a04fd-b4c3-4e95-b923-57dc84e66326",
+          "name": "srt:features",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"packageSearchCustomParams\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:features",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "31c0dd4e-35b5-4eaf-8929-3453e4ded87b",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "337aa0f9-2e11-4f8b-8d1b-547fc255d1c2",
+          "name": "srt:client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "4ba3d1a7-5d61-4230-9de0-94ea4a68d645",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"beta\", \"qa\", \"development\", \"ephemeral\", \"sandbox\", \"test\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "ffae873c-f2f2-4a62-8aae-bea0e6d8eff6",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"whoami\", \"packageSearches\", \"businessRules\", \"packageSearchResults\", \"search\", \"zone\", \"zones\", \"deliveries\", \"delivery\", \"deliverySlots\", \"drivers\", \"driver\", \"calculateDistanceAndDuration\", \"invitableDrivers\", \"savedSearches\", \"zones\", \"clients\", \"fleets\", \"preOrderETA\", \"package\", \"packages\", \"userGroup\", \"geocode\", \"reverseGeocode\", \"unfixGeocode\", \"fixGeocode\", \"featureFlags\",\"shifts\",\"webhooks\",\"webhookTopics\", \"endCustomerPackage\"]",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "b479cfc6-a416-4c30-a8b9-7f43ddbf9f6e",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "901c0c02-0126-46db-8598-a8c951857fd9",
+          "name": "zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "aggregate.attrs": "true",
+            "userinfo.token.claim": "false",
+            "multivalued": "true",
+            "user.attribute": "zone_codes",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c1d2d046-3cb1-4ad2-834d-485d93225d73",
+          "name": "srt:zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "1f0e8cdd-136f-49ed-ac30-76962ee00b87",
+          "name": "str:fleet_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "str:fleet_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "f7c44125-fae0-4b99-8090-cc30e8b7feca",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"package\", \"packageSearch\", \"deleteSavedSearches\", \"schedulePackage\", \"updatePackageReference\", \"pushFraudEstimationsForBike\", \"pushFraudEstimationsForDetour\", \"pushFraudEstimationsForGps\", \"pushFraudEstimationsForSpeed\", \"resolveVehicleRoutingProblem\", \"applyEarningsMultipliers\", \"deliverySlot\",\"createWebhook\",\"deleteWebhook\",\"updateAltDropoffLocation\",\"succeedPackages\", \"zone\", \"packages\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "role_list",
+        "microprofile-jwt"
+      ],
+      "optionalClientScopes": [
+        "client_local",
+        "offline_access",
+        "graphql"
+      ],
+      "authorizationSettings": {
+        "allowRemoteResourceManagement": true,
+        "policyEnforcementMode": "ENFORCING",
+        "resources": [
+          {
+            "name": "Default Resource",
+            "type": "urn:postman-shared-suite:resources:default",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "287932cf-d965-42ba-8355-adf5be9e1a05",
+            "uris": [
+              "/*"
+            ]
+          }
+        ],
+        "policies": [],
+        "scopes": [],
+        "decisionStrategy": "UNANIMOUS"
+      }
+    },
+    {
+      "id": "b43e88fd-87da-4f0c-ae88-77cf91927cb0",
+      "clientId": "finance-engine-stuart-uk",
+      "rootUrl": "",
+      "adminUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://example.com"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "access.token.lifespan": "2592000",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "81d3028b-b33c-4e22-8a95-7272ef4e3458",
+          "name": "srt:features",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"earningQuotes\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:features",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "e6b304da-5e95-4511-812f-fb4d2d567337",
+          "name": "srt:zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "e547c614-0f44-48d2-9075-8beab9109b9e",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"earningQuote\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "be3ccc94-a85c-497d-a39d-dc76f197798a",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"delivery\", \"deliveries\", \"driver\", \"drivers\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "de21573a-8bcd-4151-9313-e8ef4cce7457",
+          "name": "srt:fleet_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:fleet_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "81b78f61-d568-4c35-97e7-ef0bb7e5e7b1",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"production\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "7de395a9-4893-407e-9d5e-79304b9a891d",
+          "name": "srt:client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "70191fa4-a029-40b3-89d5-4a7c012e50b1",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "daf2f3fd-458f-419d-ab35-feb7c446a69d",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "491b288e-3910-4ed5-8e1f-81f390db4ebc",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "8c60ef27-bda6-42d7-80db-21aa89b3f59c",
+      "clientId": "scrooge",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "localhost:3000"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "08b9e4e1-52be-4ac7-aa98-9438c001a024",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ccaf4e87-dcd8-484c-a6ab-5e47e4c49fd5",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "0cf7aacb-3733-4813-99bb-e60d618e33b5",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "76508c21-2698-4052-a451-960a41bf0bb8",
+      "clientId": "qa-test",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://example.com",
+        "http://localhost:3000/oauth/callback",
+        "https://localhost/",
+        "http://127.0.0.1:9999/oauth/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "access.token.lifespan": "28800",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "08c74c56-ebe5-4171-b603-de0d7e8f0829",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "1ead7153-9c41-4639-85e3-b76aeed42d77",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "95924319-bb71-41a9-ba30-ec4a9e7a0824",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"packageSearch\", \"deleteSavedSearches\", \"schedulePackage\"]",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "48e679cc-abd3-4782-aebe-dead1f46a900",
+          "name": "str_client_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "123456",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "9744f7a3-21aa-4a53-bf70-f1437d17c25c",
+          "name": "srt:fleet_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:fleet_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "7681039a-6b72-4838-a048-a49d7cac0589",
+          "name": "srt:zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"barcelona\", \"paris\"]",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "c48738ab-75c4-4454-a751-5a425a8f31d8",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "168d0faf-76bf-4ca0-b49a-b1379ad7e366",
+          "name": "Srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"whoami\", \"search\", \"zone\", \"deliveries\", \"delivery\", \"drivers\", \"driver\", \"__schema\", \"geocode\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "graphql",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "ad70d3f1-5a8a-4375-8af7-f0c87e09a362",
+      "clientId": "backoffice-multiplier-uploader",
+      "rootUrl": "http://localhost:3000/oauth/callback",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost:3000/oauth/callback",
+        "http://127.0.0.1:9999/oauth/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "7f9559ef-6de4-4ab7-957f-51dc858fbc49",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "59cf5533-6b71-441b-a18e-0d0bcb72f0b9",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ed0b6540-1655-4565-930e-eeec565ac859",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"applyEarningsMultipliers\"]",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "4e2b6dc8-65ba-4de2-b308-fa5d24b2bbd7",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "99f24b1d-b1d3-4b61-b644-e86be2d0d820",
+          "name": "srt:client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "ddb8b402-72ad-46b5-ac3f-8ae01719dd51",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"beta\", \"qa\", \"development\", \"ephemeral\", \"sandbox\", \"test\", \"production\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "3920ae6f-f503-4193-87d9-f0b88173df16",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"whoami\", \"zone\"]",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "8614de50-3c6e-4236-958f-80a613249841",
+      "clientId": "courier-tags",
+      "name": "Solutions Courier tagging tool",
+      "description": "Running a test case to add incentives per invitation to a certain subset of packages that fulfil our test criteria (pending for too long in Cardiff)",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost:3000/"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "ef6c60cf-01af-4518-a978-8db85d84a81b",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"beta\",  \"production\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "e88f8510-6a26-4cb9-a42d-5d85b328383e",
+          "name": "srt:client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "c9cef391-dca9-4cfa-88b4-52f488c6eb2f",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ef917aee-c7aa-4ddf-abcd-c56bc9ba9228",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"whoami\", \"package\", \"packages\"]",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "3971e4d9-e02f-451b-8ab2-cce083e1c78b",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"incentive\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "54958a42-fbee-4993-8ff2-d2bb19ec530e",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "a283b343-c20f-4d23-a0a2-3d408f5e8fdc",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ],
+      "authorizationSettings": {
+        "allowRemoteResourceManagement": true,
+        "policyEnforcementMode": "ENFORCING",
+        "resources": [
+          {
+            "name": "Default Resource",
+            "type": "urn:courier-tags:resources:default",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "aaf78373-1b29-4952-bf13-86e057c98f1b",
+            "uris": [
+              "/*"
+            ]
+          }
+        ],
+        "policies": [
+          {
+            "id": "bbbe2e58-5327-44c3-bb77-419848b73538",
+            "name": "Default Policy",
+            "description": "A policy that grants access only for users within this realm",
+            "type": "js",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "code": "// by default, grants any permission associated with this policy\n$evaluation.grant();\n"
+            }
+          },
+          {
+            "id": "a4aaacf5-adec-4c99-9a68-1545082d2e1b",
+            "name": "Default Permission",
+            "description": "A permission that applies to the default resource type",
+            "type": "resource",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "defaultResourceType": "urn:courier-tags:resources:default",
+              "applyPolicies": "[\"Default Policy\"]"
+            }
+          }
+        ],
+        "scopes": [],
+        "decisionStrategy": "UNANIMOUS"
+      }
+    },
+    {
+      "id": "82012f89-ea01-40dc-b454-ecad867d7812",
+      "clientId": "app-toby-spain",
+      "name": "Toby: For Spain",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://gemma-stuart.ngrok.io/webhooks/stuart_sso/webhook*",
+        "http://127.0.0.1:9999/oauth/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "access.token.lifespan": "3600",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "login_theme": "stuartdefault",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "5d4a0dc1-f372-4fa9-b055-ef0a294a8c0c",
+          "name": "srt:zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"paris\", \"lyon\", \"bourdeaux\", \"toulouse\", \"montpellier\", \"limoges\", \"nantes\", \"perigueux\", \"strasbourg\", \"lille\", \"grenoble\", \"rennes\", \"dijon\", \"amiens\", \"nice\", \"nancy\", \"metz\", \"marseille\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "e1e8d0c7-2c63-4efe-ac64-3360832fe6f3",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"packages\", \"deliveries\",\"tasks\",\"whoami\",\"delivery\",\"driver\",\"packageSearch\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "97272904-ab24-416e-bc96-f542e7c89575",
+          "name": "srt:client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "ef12f220-bd2a-48fa-a9f5-d98b681386ff",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "a6df9dca-da8b-436a-8f9a-efbb05743c01",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "6d2a28f9-c3d2-475a-b85b-f99b30db29ac",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "18c1cabb-cf0a-41f6-bb27-93e75121c074",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"development\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "c7622eb8-c9bc-45ce-8329-810480af1fa8",
+          "name": "srt:features",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:features",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "7589e188-c189-424f-a2d5-9a5f3cc2196b",
+          "name": "srt:flags",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"pii\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:flags",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "4d4fd9c0-f695-4e84-928e-371d98f939c1",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"packageSearch\", \"package\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "role_list",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt",
+        "graphql"
+      ]
+    },
+    {
+      "id": "543a8a20-56b9-40b8-aafd-b7f68bed515b",
+      "clientId": "ship3-fraud",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost:3000/"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "7132d1dc-ee7a-4846-a515-b83ee5e928e0",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "9564632a-51b5-4bb1-8154-b61e779bec62",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"pushFraudEstimationsForTransportType\", \"pushFraudEstimationsForDetour\", \"pushFraudEstimationsForGps\", \"pushFraudEstimationsForSpeed\", \"pushFraudEstimationsForTransportType\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "0375af01-043b-4b38-88d2-77fb59b2c15e",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"beta\", \"qa\", \"development\", \"ephemeral\", \"sandbox\", \"test\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "9a9257bb-ae2c-47ee-9627-83539bab19fe",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "402794f4-dcb4-4539-b038-dc3f8c62c9e1",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "35d9a629-d73d-4557-8e9e-f1d6c5cddf3a",
+          "name": "srt:features",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"pushFraudEstimations\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:features",
+            "jsonType.label": "JSON"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "role_list"
+      ],
+      "optionalClientScopes": []
+    },
+    {
+      "id": "c4075448-5e5c-4e70-8691-499006c51c95",
+      "clientId": "ids-proxy",
+      "rootUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost/",
+        "http://127.0.0.1:9999/oauth/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "login_theme": "keycloak",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "5351172a-0736-4745-a1bd-c01e0c351ba5",
+          "name": "srt:client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "236e1e0a-cf51-41bb-add3-c972e9208409",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"whoami\", \"calculateDistanceAndDuration\", \"geocode\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "b85e255a-f4f2-4dc1-8e1d-170579e972b4",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "18f61bf3-574f-440c-ada5-26f2757495be",
+          "name": "srt:subscriptions",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "jsonType.label": "JSON",
+            "claim.value": "[]",
+            "userinfo.token.claim": "false"
+          }
+        },
+        {
+          "id": "97fff416-7258-44cb-8dff-90d82d1598ae",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "31bae897-35f0-49a6-b1b2-bf4195a631a0",
+          "name": "srt:zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "055046da-949a-451e-bcb2-c08363110d34",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "269ce7a8-6505-454c-b735-0a67390997da",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"beta\", \"qa\", \"development\", \"ephemeral\", \"sandbox\", \"test\", \"production\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "f7c423f6-965a-4bb7-a1cc-209aa3eec89a",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"schedulePackage\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "role_list",
+        "microprofile-jwt"
+      ],
+      "optionalClientScopes": [
+        "client_local",
+        "graphql"
+      ],
+      "authorizationSettings": {
+        "allowRemoteResourceManagement": true,
+        "policyEnforcementMode": "ENFORCING",
+        "resources": [
+          {
+            "name": "Default Resource",
+            "type": "urn:ids-proxy:resources:default",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "1fb76849-940a-4aaf-b8d7-bb821966604e",
+            "uris": [
+              "/*"
+            ]
+          }
+        ],
+        "policies": [
+          {
+            "id": "1e6bdb3e-3ce1-4739-8cdb-539eaf67f0ce",
+            "name": "Default Policy",
+            "description": "A policy that grants access only for users within this realm",
+            "type": "js",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "code": "// by default, grants any permission associated with this policy\n$evaluation.grant();\n"
+            }
+          },
+          {
+            "id": "6eb04066-e71d-4289-8275-83b68e137f3c",
+            "name": "Default Permission",
+            "description": "A permission that applies to the default resource type",
+            "type": "resource",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "defaultResourceType": "urn:ids-proxy:resources:default",
+              "applyPolicies": "[\"Default Policy\"]"
+            }
+          }
+        ],
+        "scopes": [],
+        "decisionStrategy": "AFFIRMATIVE"
+      }
+    },
+    {
+      "id": "d60ee94d-207f-4fef-94d5-75d80649951a",
+      "clientId": "stuart-poeta-visualization",
+      "name": "POETAs",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://poeta-ui.beta.stuart.com/oauth/callback",
+        "http://localhost:3000/oauth/callback",
+        "http://localhost:3000/oauth/callback/apps",
+        "http://127.0.0.1:9999/oauth/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "login_theme": "stuartdefault",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "d0b02900-b322-404c-bb47-bd0ecfd8699e",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"whoami\", \"search\", \"zone\", \"zones\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "6e27528e-2958-4cad-a0b2-401ae24feca5",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c6934aeb-86c4-4f14-8f54-cf0c3a4bb2dd",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ed9c5741-d0bc-4faa-ad0e-14b888436dc3",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "graphql",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ],
+      "authorizationSettings": {
+        "allowRemoteResourceManagement": true,
+        "policyEnforcementMode": "ENFORCING",
+        "resources": [
+          {
+            "name": "Default Resource",
+            "type": "urn:stuart-poeta-visualization:resources:default",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "f54dff9f-6bea-4e8d-a770-8959a39fbd24",
+            "uris": [
+              "/*"
+            ]
+          }
+        ],
+        "policies": [
+          {
+            "id": "e32d837b-127c-48d7-a09e-8a6ba5079988",
+            "name": "Default Policy",
+            "description": "A policy that grants access only for users within this realm",
+            "type": "js",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "code": "// by default, grants any permission associated with this policy\n$evaluation.grant();\n"
+            }
+          },
+          {
+            "id": "f08e23fc-2c24-4e40-ade8-6b132f012a80",
+            "name": "Default Permission",
+            "description": "A permission that applies to the default resource type",
+            "type": "resource",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "defaultResourceType": "urn:stuart-poeta-visualization:resources:default",
+              "applyPolicies": "[\"Default Policy\"]"
+            }
+          }
+        ],
+        "scopes": [],
+        "decisionStrategy": "UNANIMOUS"
+      }
+    },
+    {
+      "id": "bf5f8149-ecd8-4546-be64-a03056591eb2",
+      "clientId": "stuart-api-socket",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://127.0.0.1:9999/oauth/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "94f0422f-de64-4ab6-88e5-0d117657b5a8",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "91a3da17-eea6-444d-912e-37d036809b9e",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"production\",\"beta\",\"development\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "ee7bec95-f927-4fb7-aec2-b8678eae1791",
+          "name": "srt:zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "bc4ff659-1c7a-4ea1-ad80-460318fc8f99",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"zones\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "ada9c6aa-bfc6-45cc-8cad-f8ec0fec2c25",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "4d4ccac2-cd45-43aa-9a34-54a647630182",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "2ec1d828-17e5-4433-8377-e2f72643da17",
+      "clientId": "dkljdfklasdas",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "24675fd5-c48e-4ab5-af2f-1ba7314087e5",
+      "clientId": "stuart-mc",
+      "name": "Mission Control",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost:3002/oauth/callback",
+        "https://flow.stuart.com/oauth/callback",
+        "https://flow-eph-0kkypd.dev.stuart.com/oauth/callback",
+        "https://flow-eph-r4koi8.dev.stuart.com/oauth/callback",
+        "http://localhost:3000/oauth/callback",
+        "https://flow-eph-iklw2q.dev.stuart.com/oauth/callback",
+        "https://flow-eph-ttr4i0.dev.stuart.com/oauth/callback",
+        "https://flow-eph-mdanrp.dev.stuart.com/oauth/callback",
+        "https://flow-eph-rk1mbq.dev.stuart.com/oauth/callback",
+        "https://flow-eph-wbxj7z.dev.stuart.com/oauth/callback",
+        "https://flow-eph-1maztj.dev.stuart.com/oauth/callback",
+        "https://flow-eph-28ed5q.dev.stuart.com/oauth/callback",
+        "https://flow-eph-ylio0k.dev.stuart.com/oauth/callback",
+        "https://flow-eph-y7jwxv.dev.stuart.com/oauth/callback",
+        "http://127.0.0.1:9999/oauth/callback",
+        "https://flow.beta.stuart.com/oauth/callback",
+        "https://flow-eph-emzcoe.dev.stuart.com/oauth/callback",
+        "https://flow-eph-hirui7.dev.stuart.com/oauth/callback",
+        "https://flow-eph-jinpl5.dev.stuart.com/oauth/callback",
+        "https://flow-eph-n1nm7s.dev.stuart.com/oauth/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "login_theme": "stuartdefault",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {
+        "browser": "e0c1c019-ee8a-4015-8eb4-3032468ee181"
+      },
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "7e2a562a-8446-4a9f-aa73-0574d9e1f4d0",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "feb27e19-cd48-4581-96fe-28f6b2631503",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"userGroup\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "95b6a8fa-783a-41c2-a362-35d36ac40b32",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "f7aebd14-4136-4d90-960d-79a54407c940",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "graphql",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ],
+      "authorizationSettings": {
+        "allowRemoteResourceManagement": true,
+        "policyEnforcementMode": "ENFORCING",
+        "resources": [
+          {
+            "name": "Default Resource",
+            "type": "urn:stuart-mc:resources:default",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "e7335df4-ff19-4bd2-80b3-5d3847c174ee",
+            "uris": [
+              "/*"
+            ]
+          }
+        ],
+        "policies": [
+          {
+            "id": "4637d4e2-db24-4ebd-a588-63cea009d9a2",
+            "name": "Default Policy",
+            "description": "A policy that grants access only for users within this realm",
+            "type": "js",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "code": "// by default, grants any permission associated with this policy\n$evaluation.grant();\n"
+            }
+          },
+          {
+            "id": "cd06480a-b18a-4c0f-90b8-b1c1245b2319",
+            "name": "Default Permission",
+            "description": "A permission that applies to the default resource type",
+            "type": "resource",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "defaultResourceType": "urn:stuart-mc:resources:default",
+              "applyPolicies": "[\"Default Policy\"]"
+            }
+          }
+        ],
+        "scopes": [],
+        "decisionStrategy": "UNANIMOUS"
+      }
+    },
+    {
+      "id": "ab0f688b-c609-43a6-b286-36af406155b2",
+      "clientId": "internal-app-toby",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "36570e43-8272-426a-998f-a528a23a6d23",
+      "clientId": "delivery-slots",
+      "rootUrl": "https://example.com/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "https://flow.stuart.com/oauth/callback/apps",
+        "http://localhost:3000/oauth/callback/apps",
+        "http://127.0.0.1:9999/oauth/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {
+        "browser": "e0c1c019-ee8a-4015-8eb4-3032468ee181"
+      },
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "6dc40d0c-db04-4880-be9a-2d7d5f626d44",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "748d165a-5c79-4a35-8662-76bbbf6d9978",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"clients\", \"deliverySlots\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "d5ae97d2-47f2-4851-8e53-6ba8bb018aba",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"deliverySlot\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "0d1f62e2-d90a-4029-8d68-302966c84c10",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "7507b6ac-d54e-4feb-9672-ccf1860dede0",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "role_list",
+        "profile",
+        "graphql",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ],
+      "authorizationSettings": {
+        "allowRemoteResourceManagement": true,
+        "policyEnforcementMode": "ENFORCING",
+        "resources": [
+          {
+            "name": "Default Resource",
+            "type": "urn:delivery-slots:resources:default",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "7d3eefd2-5429-4281-ae99-5e1091d479ed",
+            "uris": [
+              "/*"
+            ]
+          }
+        ],
+        "policies": [
+          {
+            "id": "31d2b683-508c-4175-b150-39dce66b0022",
+            "name": "Default Policy",
+            "description": "A policy that grants access only for users within this realm",
+            "type": "js",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "code": "// by default, grants any permission associated with this policy\n$evaluation.grant();\n"
+            }
+          },
+          {
+            "id": "e279c242-23a8-4760-826c-27779d27b8b3",
+            "name": "Default Permission",
+            "description": "A permission that applies to the default resource type",
+            "type": "resource",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "defaultResourceType": "urn:delivery-slots:resources:default",
+              "applyPolicies": "[\"Default Policy\"]"
+            }
+          }
+        ],
+        "scopes": [],
+        "decisionStrategy": "UNANIMOUS"
+      }
+    },
+    {
+      "id": "007ac65b-ba92-45c4-aea5-bf37ce95c2b3",
+      "clientId": "ssp-proxy",
+      "name": "Stuart State Projector Proxy",
+      "description": "SSP receives requets for zone, client and driver info which it cannot serve itself. This gives permission for SSP to fetch that info from the v3 API.",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost:3000/auth/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "beec16f1-18a2-4748-a350-df77c1bbe6a3",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"zone\", \"zones\", \"driver\", \"client\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "27c70bb9-b2e3-4287-a11b-f18d48a4d018",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c61cc284-ca71-47d9-a016-5093515d0412",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "2b3bfc36-4988-43f7-880f-f022fabd37ee",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "3247a1c3-63d0-4c1a-abb8-6f68a3d5ba65",
+      "clientId": "new-dma",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://127.0.0.1:9999/oauth/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": true,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "true",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "driver:identity",
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "257d563e-8efd-46bc-895a-a559117cf1ec",
+      "clientId": "solutions-routing",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://127.0.0.1:9999/oauth/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "5c716f2b-cf91-48f0-851b-b23e4283893f",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "02208d03-92dc-447a-9d39-12f9509190ac",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"whoami\", \"calculateDistanceAndDuration\",\"geocode\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "beb68532-53ec-4b60-85b1-996dd5cffb07",
+          "name": "srt:zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "5023c532-0c71-4c5d-83f6-4ee896513f01",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "8cbb250c-b0d6-4529-886a-ae468712df97",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"beta\", \"qa\", \"development\", \"ephemeral\", \"sandbox\", \"test\", \"production\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "59cb91b0-698d-4cb7-ad54-0f361e218aeb",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "1bc2b4b4-992f-4d8d-8ad0-c78b1bc3e676",
+      "clientId": "pick-n-pay",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "https://oauth.pstmn.io/v1/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "0e4e7714-c457-437f-9650-7793b5920aa2",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "11ac9f30-786e-433e-a836-da3c043aa9b1",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"beta\", \"sandbox\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "9046cc7d-9752-4f99-a0da-fa6c25cf1d45",
+          "name": "srt:client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"442841 \"]",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "f779f1d6-67af-4bd9-a303-cb9dc898367c",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d92c76eb-e467-4911-ab62-f4b72a08903f",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"tip\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "a31150cc-7afe-431b-a7ce-c15d8db4a798",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d8e7d725-c8df-4e39-8d6e-eb3cdb4c8c7e",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"whoami\"]",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "role_list",
+        "microprofile-jwt"
+      ],
+      "optionalClientScopes": [
+        "client_local",
+        "offline_access",
+        "graphql"
+      ],
+      "authorizationSettings": {
+        "allowRemoteResourceManagement": true,
+        "policyEnforcementMode": "ENFORCING",
+        "resources": [
+          {
+            "name": "Default Resource",
+            "type": "urn:pick-n-pay:resources:default",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "57260f44-99c9-4ebe-aedb-6f3a2afffbeb",
+            "uris": [
+              "/*"
+            ]
+          }
+        ],
+        "policies": [
+          {
+            "id": "de0601b4-2bdf-4065-af8d-f2f768718cce",
+            "name": "Default Policy",
+            "description": "A policy that grants access only for users within this realm",
+            "type": "js",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "code": "// by default, grants any permission associated with this policy\n$evaluation.grant();\n"
+            }
+          },
+          {
+            "id": "58f1387f-8fc1-4c61-93a5-aff93b2704a0",
+            "name": "Default Permission",
+            "description": "A permission that applies to the default resource type",
+            "type": "resource",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "defaultResourceType": "urn:pick-n-pay:resources:default",
+              "applyPolicies": "[\"Default Policy\"]"
+            }
+          }
+        ],
+        "scopes": [],
+        "decisionStrategy": "UNANIMOUS"
+      }
+    },
+    {
+      "id": "6cc67e45-49c8-45dd-8ea1-25f90cbf30e3",
+      "clientId": "stuart-mc-package-app",
+      "name": "Packages List",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "https://flow.beta.stuart.com/oauth/callback/apps",
+        "https://flow-eph-wbxj7z.dev.stuart.com/oauth/callback/apps",
+        "https://flow-eph-r4koi8.dev.stuart.com/oauth/callback/apps",
+        "https://flow-eph-28ed5q.dev.stuart.com/oauth/callback/apps",
+        "https://flow-eph-iklw2q.dev.stuart.com/oauth/callback/apps",
+        "https://flow-eph-ylio0k.dev.stuart.com/oauth/callback/apps",
+        "https://flow.stuart.com/oauth/callback/apps",
+        "https://flow-eph-y7jwxv.dev.stuart.com/oauth/callback/apps",
+        "http://localhost:3000/oauth/callback/apps",
+        "https://flow-eph-1maztj.dev.stuart.com/oauth/callback/apps",
+        "https://flow-eph-rk1mbq.dev.stuart.com/oauth/callback/apps",
+        "https://flow-eph-ttr4i0.dev.stuart.com/oauth/callback/apps",
+        "https://flow-eph-n1nm7s.dev.stuart.com/oauth/callback/apps",
+        "https://flow-eph-0kkypd.dev.stuart.com/oauth/callback/apps",
+        "http://127.0.0.1:9999/oauth/callback",
+        "https://flow-eph-hirui7.dev.stuart.com/oauth/callback/apps",
+        "https://flow-eph-jinpl5.dev.stuart.com/oauth/callback/apps",
+        "https://flow-eph-emzcoe.dev.stuart.com/oauth/callback/apps",
+        "https://flow-eph-mdanrp.dev.stuart.com/oauth/callback/apps"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {
+        "browser": "e0c1c019-ee8a-4015-8eb4-3032468ee181"
+      },
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "b60a67c6-ee9b-47f6-b42e-0913d3c05757",
+          "name": "srt:features",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"packageSearchCustomParams\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:features",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "46c65a66-2dd9-4cdd-a9bb-882fabbccf5c",
+          "name": "srt:subscriptions",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"packageSearch\", \"search\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:subscriptions",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "c36f17f5-efae-410a-afe5-7c6e30576dcd",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c1f52c61-f364-4233-b5e3-54db68625201",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "65cebaf6-7faa-4ecb-bd97-c970703e8f38",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ad74e80d-9f29-4261-bd61-a4553577bcdd",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"whoami\", \"packages\", \"packageSearches\", \"packageSearchResults\", \"search\", \"savedSearches\", \"zone\", \"zones\", \"deliveries\", \"delivery\", \"drivers\", \"driver\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "6a82ba07-77a3-473c-9b4b-71b8129c43d8",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"packageSearch\", \"deleteSavedSearches\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "420f8f63-a070-47fe-9dae-175c27c86751",
+          "name": "srt:restrict_user_access",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "true",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "false",
+            "claim.name": "srt:restrict_user_access",
+            "jsonType.label": "boolean"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "graphql",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ],
+      "authorizationSettings": {
+        "allowRemoteResourceManagement": true,
+        "policyEnforcementMode": "ENFORCING",
+        "resources": [
+          {
+            "name": "Default Resource",
+            "type": "urn:stuart-mc-package-app:resources:default",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "a7a97c05-e856-433c-bc1f-f8a48b7a28e6",
+            "uris": [
+              "/*"
+            ]
+          }
+        ],
+        "policies": [
+          {
+            "id": "a8ecb619-b8b2-4393-8aa3-790455522891",
+            "name": "Default Policy",
+            "description": "A policy that grants access only for users within this realm",
+            "type": "js",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "code": "// by default, grants any permission associated with this policy\n$evaluation.grant();\n"
+            }
+          },
+          {
+            "id": "2915be5c-13a0-4f2f-b481-716d5fc05a54",
+            "name": "Default Permission",
+            "description": "A permission that applies to the default resource type",
+            "type": "resource",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "defaultResourceType": "urn:stuart-mc-package-app:resources:default",
+              "applyPolicies": "[\"Default Policy\"]"
+            }
+          }
+        ],
+        "scopes": [],
+        "decisionStrategy": "UNANIMOUS"
+      }
+    },
+    {
+      "id": "b5c080c3-b898-48c2-85c8-7fc531af0f05",
+      "clientId": "solutions-message-tool",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost:3000/auth/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.force.post.binding": "false",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "f1a150e5-f0ca-4a1e-9e92-8ce9ca4922fd",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"package\", \"zone\", \"zones\", \"applyEarningsMultipliers\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "30d97459-9a99-4e1a-8d0b-fd9ce6afe483",
+          "name": "srt:client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "2d770eb1-cad9-4115-8636-5b8ec9f219dd",
+          "name": "srt:flags",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"pii\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:flags",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "a77e0900-f7e7-4657-85b5-c592c90c0049",
+          "name": "srt:zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "e2973957-6d5c-4b14-a838-fe75d2ce7fc5",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "18dd582e-b292-4f0a-9f82-a7dbf33077af",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"beta\", \"qa\", \"development\", \"ephemeral\", \"sandbox\", \"test\", \"production\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "f5abe91e-eadc-4769-93e5-89a30f9fa1ff",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "125e7030-4353-4883-9a39-c5fdc83b02cd",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "6d910182-c32a-4470-8425-27a8d248ed96",
+          "name": "srt:features",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"packageIncentives\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:features",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "1793e12c-dd43-414a-845f-df895b82e9e7",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"packages\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "68388551-c915-4293-803b-b6feccb0d747",
+          "name": "srt:client_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"0\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_id",
+            "jsonType.label": "JSON"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt",
+        "graphql"
+      ]
+    },
+    {
+      "id": "d8012a59-8fe5-41c2-b3c9-5dc7907889f3",
+      "clientId": "courier-slots",
+      "name": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost:3000/oauth/callback/apps"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "20030040-1f48-49df-9f93-a98cfc8083ec",
+      "clientId": "vargas-mvp-test",
+      "rootUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost:12321",
+        "http://localhost:3000/oauth/callback",
+        "https://localhost/",
+        "http://127.0.0.1:9999/oauth/callback",
+        "https://oauth.pstmn.io/v1/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "authorizationServicesEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "login_theme": "keycloak",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "6359b8f7-32a2-4ac1-b52e-70488432d0e7",
+          "name": "srt:environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"beta\", \"qa\", \"development\", \"ephemeral\", \"sandbox\", \"test\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "fc3f6288-cbbe-4eaa-a09a-9b7d7c9f3fdf",
+          "name": "str:fleet_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "str:fleet_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "6a838ddc-eef8-404e-987d-710b3fe58422",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"packageSearches\", \"packageSearchResults\", \"search\", \"deliveries\", \"delivery\", \"deliverySlots\",  \"preOrderETA\", \"package\", \"packages\", \"geocode\", \"reverseGeocode\", \"unfixGeocode\", \"fixGeocode\", \"webhooks\",\"webhookTopics\"]",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "67f36878-f0f4-4797-bf51-6360db0651a2",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "a56282bb-f48f-4730-b4fc-6819ea864524",
+          "name": "srt:mutations",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"package\", \"packageSearch\", \"deleteSavedSearches\",\"updatePackageReference\",\"createWebhook\",\"deleteWebhook\",\"updateAltDropoffLocation\", \"packages\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:mutations",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "bd75091c-3cf9-471a-ba39-5d19a828f03d",
+          "name": "zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "aggregate.attrs": "true",
+            "userinfo.token.claim": "false",
+            "multivalued": "true",
+            "user.attribute": "zone_codes",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "4a2ed050-92fa-45e9-b025-a40a3e123391",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "9812b35c-33bd-4ba2-beff-51028e938542",
+          "name": "srt:client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "dc141a99-9842-4078-b457-28cd7c9edacf",
+          "name": "srt:zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"any\"]",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "70783b30-4259-4ac5-9aed-c75fd03af490",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "graphql",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ],
+      "authorizationSettings": {
+        "allowRemoteResourceManagement": true,
+        "policyEnforcementMode": "ENFORCING",
+        "resources": [
+          {
+            "name": "Default Resource",
+            "type": "urn:vargas-mvp-test:resources:default",
+            "ownerManagedAccess": false,
+            "attributes": {},
+            "_id": "41fecfc3-12c8-4c84-ac0b-c2c1ef7385d3",
+            "uris": [
+              "/*"
+            ]
+          }
+        ],
+        "policies": [
+          {
+            "id": "665f65cb-dbf7-448d-81b1-eadf2ffbc0ca",
+            "name": "Default Policy",
+            "description": "A policy that grants access only for users within this realm",
+            "type": "js",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "code": "// by default, grants any permission associated with this policy\n$evaluation.grant();\n"
+            }
+          },
+          {
+            "id": "63fb61ea-4abc-40b3-9e4b-bfb8d8ba1477",
+            "name": "Default Permission",
+            "description": "A permission that applies to the default resource type",
+            "type": "resource",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "defaultResourceType": "urn:vargas-mvp-test:resources:default",
+              "applyPolicies": "[\"Default Policy\"]"
+            }
+          }
+        ],
+        "scopes": [],
+        "decisionStrategy": "UNANIMOUS"
+      }
+    },
+    {
+      "id": "c93341c4-4e49-4396-9490-035758e6437e",
+      "clientId": "stuart-end-customer-page",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost:3000/callback"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.multivalued.roles": "false",
+        "saml.force.post.binding": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "22cb16eb-8537-4567-a537-c7ada6d587cf",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "7b281282-3fd1-424b-a85b-0564dd068c6c",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "638c499a-cacf-4ffa-8ef9-ad099cb81250",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "40134163-8885-4a7a-baec-49445d1909c8",
+          "name": "srt:queries",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"whoami\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:queries",
+            "jsonType.label": "JSON"
+          }
+        },
+        {
+          "id": "07f47476-d8c2-4320-b38b-2c1c0372b465",
+          "name": "srt:features",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "[\"earningQuotes\"]",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:features",
+            "jsonType.label": "JSON"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "id": "cd1b8f73-4ac4-4275-aa00-9401e3374a1d",
+      "name": "address",
+      "description": "OpenID Connect built-in scope: address",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${addressScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "e6e11ab6-510a-48b7-ab83-d1dc276aabc4",
+          "name": "address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-address-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute.formatted": "formatted",
+            "user.attribute.country": "country",
+            "user.attribute.postal_code": "postal_code",
+            "userinfo.token.claim": "true",
+            "user.attribute.street": "street",
+            "id.token.claim": "true",
+            "user.attribute.region": "region",
+            "access.token.claim": "true",
+            "user.attribute.locality": "locality"
+          }
+        }
+      ]
+    },
+    {
+      "id": "4d1b5f8e-99e3-47d1-b751-1fba11dc5a63",
+      "name": "email",
+      "description": "OpenID Connect built-in scope: email",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${emailScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "93f84bb2-4cbe-4e63-87ca-faf8cf7a98f3",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "3ac3835d-0385-485a-934d-8318b7c63c93",
+          "name": "email verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "emailVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email_verified",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "id": "3a81dc05-583f-46fa-b905-64abd24e47c1",
+      "name": "graphql",
+      "description": "Carries the GraphQL permission schema attribute mappers",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "c2f5ced0-8dae-4c4b-98e5-583b1ccd8054",
+          "name": "admin_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "false",
+            "user.attribute": "admin_id",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:admin_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "103bf575-9b5e-4f70-9075-c869e2e92a92",
+          "name": "environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "aggregate.attrs": "true",
+            "multivalued": "true",
+            "userinfo.token.claim": "false",
+            "user.attribute": "environments",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d7d51a9c-2603-4c07-a2a2-d317fec88a09",
+          "name": "zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "aggregate.attrs": "true",
+            "multivalued": "true",
+            "userinfo.token.claim": "false",
+            "user.attribute": "zone_codes",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "4e3ff890-a8c0-420b-9cea-23828271c92f",
+          "name": "fleet_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "aggregate.attrs": "true",
+            "multivalued": "true",
+            "userinfo.token.claim": "false",
+            "user.attribute": "fleet_ids",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:fleet_ids",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "736ff81d-844c-42d5-883b-90215c998e96",
+          "name": "client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "aggregate.attrs": "true",
+            "multivalued": "true",
+            "userinfo.token.claim": "false",
+            "user.attribute": "client_ids",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "e46d998f-bde4-4512-b86d-c799e24cc26b",
+          "name": "client_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "false",
+            "user.attribute": "client_id",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "64db4f49-daf4-4c6c-9cc3-d1a31c982329",
+          "name": "driver_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "aggregate.attrs": "false",
+            "multivalued": "false",
+            "userinfo.token.claim": "false",
+            "user.attribute": "driver_id",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:driver_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "be88ed15-d857-4a25-bae4-4cac5ecaa992",
+          "name": "idp",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "false",
+            "user.attribute": "idp",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:idp",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "da1c8819-51d5-44fe-9377-ad31b3afa080",
+          "name": "flags",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "false",
+            "multivalued": "true",
+            "user.attribute": "flags",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:flags",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "53cc28d7-0f05-4f5e-a2da-e3c0fa1f2e7d",
+          "name": "features",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "false",
+            "multivalued": "true",
+            "user.attribute": "features",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:features",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "a98b4f4a-e242-4cfc-b466-d6963bbb588d",
+      "name": "microprofile-jwt",
+      "description": "Microprofile - JWT built-in scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "357535e0-a1af-40fa-9238-c42655f31332",
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "bfb84423-a302-49df-909c-b2d577f32733",
+          "name": "upn",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "upn",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "b72c88c2-f76f-47bb-b225-f6d68762d62a",
+      "name": "offline_access",
+      "description": "OpenID Connect built-in scope: offline_access",
+      "protocol": "openid-connect",
+      "attributes": {
+        "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "id": "456badf7-98e5-418f-81b4-7381d9f621f3",
+      "name": "phone",
+      "description": "OpenID Connect built-in scope: phone",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${phoneScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "b1ff5727-80d9-46d9-8ad2-28928364634d",
+          "name": "phone number",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumber",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "0d5d733f-eedf-4402-a9e8-5015436be8f4",
+          "name": "phone number verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumberVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number_verified",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "id": "5512022e-e817-4e36-b288-0bd7866cc9ea",
+      "name": "profile",
+      "description": "OpenID Connect built-in scope: profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${profileScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "1e4a1a36-8ffa-448f-81c5-72c1be496ea4",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "7f2b4195-8685-4c4d-8cbc-3e837b84daa1",
+          "name": "gender",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "gender",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "gender",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "a90f97bb-22eb-46b6-9668-d9980a927a52",
+          "name": "nickname",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "nickname",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "nickname",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c24512a0-76a1-40b2-8681-135e152c36d3",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "299e423c-4e16-4e83-8e07-05731daaa6b9",
+          "name": "picture",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "picture",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "picture",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "948d2795-2982-4e53-9147-21c67267f95a",
+          "name": "middle name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "middleName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "middle_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "0abdd2d5-c8b6-41ee-aaa4-020cd6d1ab57",
+          "name": "birthdate",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "birthdate",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "birthdate",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "7071871c-7310-473b-be95-5f923979cf62",
+          "name": "updated at",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "updatedAt",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "updated_at",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "5803a398-0a70-4974-9bb0-db1347923f3e",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c2b1bcda-be94-474d-af10-90eff2ae7451",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ac1b0b3f-e5d7-4884-a6bd-42a842443276",
+          "name": "profile",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "profile",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "profile",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "fef5d358-d29c-4641-9e95-6828ffa7a825",
+          "name": "website",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "website",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "website",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "6ad7c82a-6ec3-4208-89e2-9d3f696abe3c",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c1b6ad45-4789-4656-8efb-a470a872b6f7",
+          "name": "zoneinfo",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "zoneinfo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "zoneinfo",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "0bb235ae-a789-47b5-ad3b-1883b45225f0",
+      "name": "role_list",
+      "description": "SAML role list",
+      "protocol": "saml",
+      "attributes": {
+        "consent.screen.text": "${samlRoleListScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "b8ce7cf3-fe12-4016-80e2-253c5f9c8d34",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        }
+      ]
+    },
+    {
+      "id": "8068afab-0c65-4b07-b3be-b8ef6be169f9",
+      "name": "roles",
+      "description": "OpenID Connect scope for add user roles to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${rolesScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "12251252-d119-45ba-9c9c-31cfcbcff006",
+          "name": "client roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "resource_access.${client_id}.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "0d4ee838-4651-49f8-a37c-4453a69882bd",
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "f9959649-534d-4c75-ad60-e982f5233282",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ]
+    },
+    {
+      "id": "27ce23a0-f7b5-4a4a-8f61-47bd83a9e328",
+      "name": "web-origins",
+      "description": "OpenID Connect scope for add allowed web origins to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false",
+        "consent.screen.text": ""
+      },
+      "protocolMappers": [
+        {
+          "id": "66039beb-7c4b-4cfa-9df0-2edab5386c08",
+          "name": "allowed web origins",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-allowed-origins-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ]
+    },
+    {
+      "id": "3ed4016b-bd7d-41a2-916d-158450fa0ef4",
+      "name": "driver:identity",
+      "description": "Allow app to request putting driver ID specifics in the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "This app would like to read your driver identity."
+      },
+      "protocolMappers": [
+        {
+          "id": "7250dd2e-63cc-4466-8cf6-95d7bf41da2c",
+          "name": "srt:driver_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "false",
+            "user.attribute": "driver_id",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:driver_id",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "53895eb2-57e8-4f79-b984-d7430ea0dd42",
+      "name": "client_local",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "a036330a-951f-48de-9a3d-3288b2656cbf",
+          "name": "srt:client_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "9",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_id",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "role_list",
+    "profile",
+    "email",
+    "roles",
+    "web-origins"
+  ],
+  "defaultOptionalClientScopes": [
+    "offline_access",
+    "address",
+    "phone",
+    "microprofile-jwt"
+  ],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection": "1; mode=block",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer": {},
+  "loginTheme": "stuartdefault",
+  "eventsEnabled": true,
+  "eventsListeners": [
+    "jboss-logging"
+  ],
+  "enabledEventTypes": [
+    "SEND_RESET_PASSWORD",
+    "UPDATE_CONSENT_ERROR",
+    "GRANT_CONSENT",
+    "REMOVE_TOTP",
+    "REVOKE_GRANT",
+    "UPDATE_TOTP",
+    "LOGIN_ERROR",
+    "CLIENT_LOGIN",
+    "RESET_PASSWORD_ERROR",
+    "IMPERSONATE_ERROR",
+    "CODE_TO_TOKEN_ERROR",
+    "CUSTOM_REQUIRED_ACTION",
+    "RESTART_AUTHENTICATION",
+    "IMPERSONATE",
+    "UPDATE_PROFILE_ERROR",
+    "LOGIN",
+    "UPDATE_PASSWORD_ERROR",
+    "CLIENT_INITIATED_ACCOUNT_LINKING",
+    "TOKEN_EXCHANGE",
+    "LOGOUT",
+    "REGISTER",
+    "CLIENT_REGISTER",
+    "IDENTITY_PROVIDER_LINK_ACCOUNT",
+    "UPDATE_PASSWORD",
+    "CLIENT_DELETE",
+    "FEDERATED_IDENTITY_LINK_ERROR",
+    "IDENTITY_PROVIDER_FIRST_LOGIN",
+    "CLIENT_DELETE_ERROR",
+    "VERIFY_EMAIL",
+    "CLIENT_LOGIN_ERROR",
+    "RESTART_AUTHENTICATION_ERROR",
+    "EXECUTE_ACTIONS",
+    "REMOVE_FEDERATED_IDENTITY_ERROR",
+    "TOKEN_EXCHANGE_ERROR",
+    "PERMISSION_TOKEN",
+    "SEND_IDENTITY_PROVIDER_LINK_ERROR",
+    "EXECUTE_ACTION_TOKEN_ERROR",
+    "SEND_VERIFY_EMAIL",
+    "EXECUTE_ACTIONS_ERROR",
+    "REMOVE_FEDERATED_IDENTITY",
+    "IDENTITY_PROVIDER_POST_LOGIN",
+    "IDENTITY_PROVIDER_LINK_ACCOUNT_ERROR",
+    "UPDATE_EMAIL",
+    "REGISTER_ERROR",
+    "REVOKE_GRANT_ERROR",
+    "EXECUTE_ACTION_TOKEN",
+    "LOGOUT_ERROR",
+    "UPDATE_EMAIL_ERROR",
+    "CLIENT_UPDATE_ERROR",
+    "UPDATE_PROFILE",
+    "CLIENT_REGISTER_ERROR",
+    "FEDERATED_IDENTITY_LINK",
+    "SEND_IDENTITY_PROVIDER_LINK",
+    "SEND_VERIFY_EMAIL_ERROR",
+    "RESET_PASSWORD",
+    "CLIENT_INITIATED_ACCOUNT_LINKING_ERROR",
+    "UPDATE_CONSENT",
+    "REMOVE_TOTP_ERROR",
+    "VERIFY_EMAIL_ERROR",
+    "SEND_RESET_PASSWORD_ERROR",
+    "CLIENT_UPDATE",
+    "CUSTOM_REQUIRED_ACTION_ERROR",
+    "IDENTITY_PROVIDER_POST_LOGIN_ERROR",
+    "UPDATE_TOTP_ERROR",
+    "CODE_TO_TOKEN",
+    "GRANT_CONSENT_ERROR",
+    "IDENTITY_PROVIDER_FIRST_LOGIN_ERROR"
+  ],
+  "adminEventsEnabled": true,
+  "adminEventsDetailsEnabled": false,
+  "identityProviders": [
+    {
+      "alias": "pontica",
+      "displayName": "Google from Pontica",
+      "internalId": "6f48af48-b1a7-4c0c-ae6c-ef9b8c2da048",
+      "providerId": "oidc",
+      "enabled": true,
+      "updateProfileFirstLoginMode": "on",
+      "trustEmail": true,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "authenticateByDefault": false,
+      "linkOnly": false,
+      "firstBrokerLoginFlowAlias": "first broker login",
+      "postBrokerLoginFlowAlias": "Client Access Authenticator",
+      "config": {
+        "hideOnLoginPage": "false",
+        "validateSignature": "",
+        "userInfoUrl": "https://openidconnect.googleapis.com/v1/userinfo",
+        "uiLocales": "",
+        "acceptsPromptNoneForwardFromClient": "",
+        "tokenUrl": "https://oauth2.googleapis.com/token",
+        "clientId": "105908661118-0vr0h5ho7518unl3p00vvjgo4ll5vjan.apps.googleusercontent.com",
+        "backchannelSupported": "",
+        "issuer": "https://accounts.google.com",
+        "useJwksUrl": "true",
+        "loginHint": "",
+        "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth?hd=ponticasolutions.com",
+        "clientAuthMethod": "client_secret_post",
+        "disableUserInfo": "",
+        "clientSecret": "**********",
+        "prompt": "",
+        "guiOrder": "2",
+        "defaultScope": "openid profile email"
+      }
+    },
+    {
+      "alias": "google",
+      "internalId": "543c4bf5-b51d-4056-9f4a-938cdd2d99ab",
+      "providerId": "google",
+      "enabled": true,
+      "updateProfileFirstLoginMode": "on",
+      "trustEmail": true,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "authenticateByDefault": false,
+      "linkOnly": false,
+      "firstBrokerLoginFlowAlias": "first broker login",
+      "postBrokerLoginFlowAlias": "Client Access Authenticator",
+      "config": {
+        "hideOnLoginPage": "",
+        "offlineAccess": "",
+        "acceptsPromptNoneForwardFromClient": "",
+        "clientId": "406759240425-tns0suq1ur38hre3ssdo0qerc9vhnqst.apps.googleusercontent.com",
+        "disableUserInfo": "",
+        "hostedDomain": "stuart.com",
+        "userIp": "",
+        "clientSecret": "**********",
+        "useJwksUrl": "true"
+      }
+    }
+  ],
+  "identityProviderMappers": [
+    {
+      "id": "822ca862-0975-42ed-8d55-0aef192a7733",
+      "name": "idp",
+      "identityProviderAlias": "google",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "google",
+        "attribute": "idp"
+      }
+    }
+  ],
+  "components": {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+      {
+        "id": "f778a489-2ac5-49e7-b591-54cefff26efd",
+        "name": "Trusted Hosts",
+        "providerId": "trusted-hosts",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "host-sending-registration-request-must-match": [
+            "true"
+          ],
+          "client-uris-must-match": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "0a1dd0af-9f5d-4303-bbf8-85cf4476cb76",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-usermodel-attribute-mapper",
+            "saml-user-attribute-mapper",
+            "saml-role-list-mapper",
+            "oidc-full-name-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "saml-user-property-mapper",
+            "oidc-address-mapper",
+            "oidc-usermodel-property-mapper"
+          ]
+        }
+      },
+      {
+        "id": "89efaec5-f573-4d4f-8800-9c0e35a6b50e",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "cc58da9d-a99b-4aad-963b-48e4a2c0798a",
+        "name": "Max Clients Limit",
+        "providerId": "max-clients",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "max-clients": [
+            "200"
+          ]
+        }
+      },
+      {
+        "id": "36547dca-c90d-4f58-866e-f85b541f9387",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "7fec7fac-ebd0-478b-9b62-aa8e41db43a7",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "saml-user-attribute-mapper",
+            "oidc-usermodel-property-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "saml-user-property-mapper",
+            "oidc-address-mapper",
+            "oidc-full-name-mapper",
+            "saml-role-list-mapper"
+          ]
+        }
+      },
+      {
+        "id": "1dac8e5a-d618-4926-afad-1303ae30cfc1",
+        "name": "Consent Required",
+        "providerId": "consent-required",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "b39b51e4-09f3-4af3-a8de-d3233836e33f",
+        "name": "Full Scope Disabled",
+        "providerId": "scope",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      }
+    ],
+    "org.keycloak.keys.KeyProvider": [
+      {
+        "id": "33239f9d-e793-451f-9d08-627ed1375daa",
+        "name": "fallback-HS256",
+        "providerId": "hmac-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "-100"
+          ],
+          "algorithm": [
+            "HS256"
+          ]
+        }
+      },
+      {
+        "id": "fb1c33a0-f2d3-4539-824c-16f3892e1c72",
+        "name": "ecdsa-generated",
+        "providerId": "ecdsa-generated",
+        "subComponents": {},
+        "config": {
+          "ecdsaEllipticCurveKey": [
+            "P-256"
+          ],
+          "active": [
+            "true"
+          ],
+          "priority": [
+            "0"
+          ],
+          "enabled": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "55eae381-7fcd-47ab-a740-b183545bcc38",
+        "name": "fallback-RS256",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "-100"
+          ],
+          "algorithm": [
+            "RS256"
+          ]
+        }
+      }
+    ]
+  },
+  "internationalizationEnabled": false,
+  "supportedLocales": [
+    ""
+  ],
+  "authenticationFlows": [
+    {
+      "id": "5d0d2ebe-7ae3-474a-ae35-3fdff1df8a46",
+      "alias": "Account verification options",
+      "description": "Method with which to verity the existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-email-verification",
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "flowAlias": "Verify Existing Account by Re-authentication",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "b75a3c2a-f5bc-4296-b191-ae04b9151250",
+      "alias": "Authentication Options",
+      "description": "Authentication options.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "basic-auth",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "basic-auth-otp",
+          "requirement": "DISABLED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "requirement": "DISABLED",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "f5662006-0277-4547-9837-e80686100b36",
+      "alias": "Browser",
+      "description": "",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "requirement": "ALTERNATIVE",
+          "priority": 0,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "requirement": "ALTERNATIVE",
+          "priority": 1,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-page-form",
+          "requirement": "ALTERNATIVE",
+          "priority": 2,
+          "flowAlias": "Form",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "adc721b2-765e-4560-a6c1-5697bf2272a1",
+      "alias": "Browser - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "e0c1c019-ee8a-4015-8eb4-3032468ee181",
+      "alias": "Browser With User Access Verification",
+      "description": "browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "requirement": "REQUIRED",
+          "priority": 31,
+          "flowAlias": "Browser",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        },
+        {
+          "authenticator": "script-client-authenticator.js",
+          "requirement": "REQUIRED",
+          "priority": 32,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "5d07efb7-0151-4632-b77f-60a82011c23f",
+      "alias": "Client Access Authenticator",
+      "description": "",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "script-client-authenticator.js",
+          "requirement": "REQUIRED",
+          "priority": 0,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "b3224ba1-ca2d-4470-909b-fa3e97c18499",
+      "alias": "Direct Grant - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "direct-grant-validate-otp",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "753c6467-3fe1-4068-9797-b45920e3a99e",
+      "alias": "First broker login - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "0decf3cb-7ac3-43d6-b3c0-79b8fe66e144",
+      "alias": "Form",
+      "description": "",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "requirement": "REQUIRED",
+          "priority": 0,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "446f2dcc-cd84-4d3d-832d-ecdefe38702c",
+      "alias": "Handle Existing Account",
+      "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-confirm-link",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "flowAlias": "Account verification options",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "dca943a1-baa1-4b9c-ba21-004a3c8d6129",
+      "alias": "Reset - Conditional OTP",
+      "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "reset-otp",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "05589f17-2167-402e-97ba-6ed9ec1b5c21",
+      "alias": "User creation or linking",
+      "description": "Flow for the existing/non-existing user alternatives",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "create unique user config",
+          "authenticator": "idp-create-user-if-unique",
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "flowAlias": "Handle Existing Account",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "c1a6c049-8b1c-4258-9ed9-92a3515f9cb5",
+      "alias": "Verify Existing Account by Re-authentication",
+      "description": "Reauthentication of existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-username-password-form",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "flowAlias": "First broker login - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "48620dfa-7d8d-400d-8112-b8231bcc2927",
+      "alias": "browser",
+      "description": "browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "requirement": "DISABLED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "flowAlias": "forms",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "5a76108b-bc1c-4f5d-89f8-7d5d601d91d9",
+      "alias": "clients",
+      "description": "Base authentication for clients",
+      "providerId": "client-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "client-secret",
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "client-jwt",
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "client-secret-jwt",
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "client-x509",
+          "requirement": "ALTERNATIVE",
+          "priority": 40,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "f8a257a0-b734-46a5-8c85-c54b03e74a23",
+      "alias": "direct grant",
+      "description": "OpenID Connect Resource Owner Grant",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "direct-grant-validate-username",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "direct-grant-validate-password",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "CONDITIONAL",
+          "priority": 30,
+          "flowAlias": "Direct Grant - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "2c2205af-536d-44ca-bcdc-ce1239ecf1f6",
+      "alias": "docker auth",
+      "description": "Used by Docker clients to authenticate against the IDP",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "8cd65670-e350-4004-b181-920839676ce6",
+      "alias": "first broker login",
+      "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "review profile config",
+          "authenticator": "idp-review-profile",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "flowAlias": "User creation or linking",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "ca5ba922-5c8d-4dd4-a421-9a9ac31e22ce",
+      "alias": "forms",
+      "description": "Username, password, otp and other auth forms.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "flowAlias": "Browser - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "ced3b856-80fe-4939-b173-a099282f98e6",
+      "alias": "http challenge",
+      "description": "An authentication flow based on challenge-response HTTP Authentication Schemes",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "no-cookie-redirect",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "flowAlias": "Authentication Options",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "24d66d4f-88e4-4ef7-b310-4a5d08b084b3",
+      "alias": "registration",
+      "description": "registration flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "flowAlias": "registration form",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "489aedd6-f889-4bad-b7d6-853bcdbd4fad",
+      "alias": "registration form",
+      "description": "registration form",
+      "providerId": "form-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-user-creation",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-profile-action",
+          "requirement": "REQUIRED",
+          "priority": 40,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-password-action",
+          "requirement": "REQUIRED",
+          "priority": 50,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-recaptcha-action",
+          "requirement": "DISABLED",
+          "priority": 60,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "960f3fce-7ee7-4ded-985b-0cf7f709b089",
+      "alias": "reset credentials",
+      "description": "Reset credentials for a user if they forgot their password or something",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "reset-credentials-choose-user",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "reset-credential-email",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "reset-password",
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "CONDITIONAL",
+          "priority": 40,
+          "flowAlias": "Reset - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "dc081de8-9b1d-40c5-b712-183bbef5a448",
+      "alias": "saml ecp",
+      "description": "SAML ECP Profile Authentication Flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "http-basic-authenticator",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "id": "81d487e6-b3ad-462b-9f30-527c32f959fe",
+      "alias": "create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
+      }
+    },
+    {
+      "id": "e3c8db16-e690-4d25-bf9b-9f3c0c4c139d",
+      "alias": "group-manager",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "238f0f56-249b-4182-9078-a6d76f7b9809",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "2ffc6aff-bf69-4995-866e-6b630c502418",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "4ff2cd2c-7367-4c78-b11a-f97631ed8975",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "de8968d7-b600-446f-b81d-404d7e6e1000",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "9b1e6914-905d-48c3-8af2-7f0fd29898f7",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "4d42a886-6664-4350-954a-be9eef4cb718",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "abafdc79-eac6-4d80-b353-1e6fc6f48af6",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "29588348-335d-45c6-b596-ddd9a15f1f4e",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "717f6c75-c5f1-425b-9f4f-0213cf0abab5",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "ac455d62-13ec-4863-80f6-ca11f1b11b3d",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "86bc657a-5a8d-4547-af57-537c75340420",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "7fe80a0e-5c59-4789-a52a-9ef73a0e226c",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "2dd8dc94-9e4f-4c17-8c4e-a2ee073b90f4",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "7821f341-5c28-472e-9890-e446f1a36947",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "40d3f618-f19a-4412-9a9b-ea93fde42e8a",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "2d4879af-f12d-4535-81eb-d0466234b76e",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "893bc087-6e9a-48bc-8227-418010fe822b",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "1788dc9a-3435-4c8c-a72b-94a2e433bd0d",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "5a3829fe-561c-4d8d-bf6c-5e89a59e8556",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "6ae8333a-c371-4ceb-bf16-18ddd09411f6",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "f5ae5140-f4b3-4543-978c-4c511c665467",
+      "alias": "groups-management.groups-management",
+      "config": {
+        "condUserRole": "terexa-test-ugm.groups-management"
+      }
+    },
+    {
+      "id": "6b9cf769-2880-4973-b9f4-b4832bb90cbc",
+      "alias": "review profile config",
+      "config": {
+        "update.profile.on.first.login": "missing"
+      }
+    },
+    {
+      "id": "ae9cf032-4ef4-4516-8a98-cc7dd4d62ea4",
+      "alias": "terexa-test-ugm.manager",
+      "config": {
+        "condUserRole": "terexa-test-ugm.manager"
+      }
+    }
+  ],
+  "requiredActions": [
+    {
+      "alias": "CONFIGURE_TOTP",
+      "name": "Configure OTP",
+      "providerId": "CONFIGURE_TOTP",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 10,
+      "config": {}
+    },
+    {
+      "alias": "terms_and_conditions",
+      "name": "Terms and Conditions",
+      "providerId": "terms_and_conditions",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 20,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PASSWORD",
+      "name": "Update Password",
+      "providerId": "UPDATE_PASSWORD",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 30,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PROFILE",
+      "name": "Update Profile",
+      "providerId": "UPDATE_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 40,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 50,
+      "config": {}
+    },
+    {
+      "alias": "update_user_locale",
+      "name": "Update User Locale",
+      "providerId": "update_user_locale",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 1000,
+      "config": {}
+    }
+  ],
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "attributes": {
+    "displayName": "Stuart",
+    "webAuthnPolicyAuthenticatorAttachment": "not specified",
+    "_browser_header.xRobotsTag": "none",
+    "webAuthnPolicyAttestationConveyancePreferencePasswordless": "not specified",
+    "webAuthnPolicyRequireResidentKeyPasswordless": "not specified",
+    "webAuthnPolicySignatureAlgorithmsPasswordless": "ES256",
+    "webAuthnPolicyRpEntityName": "keycloak",
+    "webAuthnPolicyAvoidSameAuthenticatorRegisterPasswordless": "false",
+    "failureFactor": "30",
+    "webAuthnPolicyAuthenticatorAttachmentPasswordless": "not specified",
+    "actionTokenGeneratedByUserLifespan": "300",
+    "maxDeltaTimeSeconds": "43200",
+    "webAuthnPolicySignatureAlgorithms": "ES256",
+    "webAuthnPolicyRpEntityNamePasswordless": "keycloak",
+    "offlineSessionMaxLifespan": "5184000",
+    "_browser_header.contentSecurityPolicyReportOnly": "",
+    "bruteForceProtected": "false",
+    "webAuthnPolicyRpIdPasswordless": "",
+    "actionTokenGeneratedByUserLifespan.reset-credentials": "300",
+    "_browser_header.contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "_browser_header.xXSSProtection": "1; mode=block",
+    "_browser_header.xFrameOptions": "SAMEORIGIN",
+    "_browser_header.strictTransportSecurity": "max-age=31536000; includeSubDomains",
+    "webAuthnPolicyUserVerificationRequirement": "not specified",
+    "permanentLockout": "false",
+    "quickLoginCheckMilliSeconds": "1000",
+    "webAuthnPolicyCreateTimeout": "0",
+    "webAuthnPolicyRequireResidentKey": "not specified",
+    "webAuthnPolicyRpId": "",
+    "webAuthnPolicyAttestationConveyancePreference": "not specified",
+    "maxFailureWaitSeconds": "900",
+    "minimumQuickLoginWaitSeconds": "60",
+    "defaultSignatureAlgorithm": "ES256",
+    "webAuthnPolicyCreateTimeoutPasswordless": "0",
+    "webAuthnPolicyAvoidSameAuthenticatorRegister": "false",
+    "webAuthnPolicyUserVerificationRequirementPasswordless": "not specified",
+    "_browser_header.xContentTypeOptions": "nosniff",
+    "actionTokenGeneratedByAdminLifespan": "43200",
+    "waitIncrementSeconds": "60",
+    "offlineSessionMaxLifespanEnabled": "false"
+  },
+  "keycloakVersion": "9.0.0",
+  "userManagedAccessAllowed": false
+}

--- a/init_config/20200211_9.0.3/realm-export-only-groups-and-roles.json
+++ b/init_config/20200211_9.0.3/realm-export-only-groups-and-roles.json
@@ -1,0 +1,3944 @@
+{
+  "id": "stuart",
+  "realm": "stuart",
+  "displayName": "Stuart",
+  "notBefore": 1607959567,
+  "defaultSignatureAlgorithm": "ES256",
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 300,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 3600,
+  "ssoSessionIdleTimeoutRememberMe": 0,
+  "ssoSessionMaxLifespanRememberMe": 0,
+  "offlineSessionIdleTimeout": 172800,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "permanentLockout": false,
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "roles": {
+    "realm": [
+      {
+        "id": "c3b2dd90-3b30-4585-98bc-10f0d4378684",
+        "name": "admin",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "stuart",
+        "attributes": {}
+      },
+      {
+        "id": "2920af97-8b68-4cd6-b773-1dab59d09826",
+        "name": "uma_authorization",
+        "description": "${role_uma_authorization}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "stuart",
+        "attributes": {}
+      },
+      {
+        "id": "86e18aa2-39c6-441b-b7f2-3a797f85fe71",
+        "name": "offline_access",
+        "description": "${role_offline-access}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "stuart",
+        "attributes": {}
+      },
+      {
+        "id": "c14bada9-752c-4710-b700-be0c978c867c",
+        "name": "postman-shared-suite",
+        "description": "Role for the postman-shared-suite client.",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "stuart",
+        "attributes": {}
+      }
+    ]
+  },
+  "groups": [
+    {
+      "id": "d67fdc23-4de3-4ac7-b619-0f3bd0da8cdb",
+      "name": "REAL Customer Support Global",
+      "path": "/REAL Customer Support Global",
+      "attributes": {
+        "zone_codes": [
+          "any"
+        ],
+        "environments": [
+          "production",
+          "beta",
+          "sandbox"
+        ],
+        "fleet_ids": [
+          "any"
+        ],
+        "allowed_application_ids": [
+          "stuart-mc-package-app"
+        ],
+        "client_ids": [
+          "any"
+        ]
+      },
+      "realmRoles": [],
+      "clientRoles": {
+        "stuart-mc-package-app": [
+          "user-access-control"
+        ]
+      },
+      "subGroups": [
+        {
+          "id": "c7372880-4bb2-44b5-8490-eff3b728c694",
+          "name": "Managers",
+          "path": "/REAL Customer Support Global/Managers",
+          "attributes": {
+            "allowed_application_ids": [
+              "management_groups",
+              "stuart-mc-package-app"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {
+            "management-groups": [
+              "user-access-control"
+            ]
+          },
+          "subGroups": []
+        },
+        {
+          "id": "c52946ae-9967-4819-a040-de969edc8207",
+          "name": "TESTING Customer Support",
+          "path": "/REAL Customer Support Global/TESTING Customer Support",
+          "attributes": {
+            "zone_codes": [
+              "any"
+            ],
+            "environments": [
+              "production"
+            ],
+            "fleet_ids": [
+              "any"
+            ],
+            "allowed_application_ids": [
+              "unset"
+            ],
+            "client_ids": [
+              "any"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {
+            "stuart-mc-package-app": [
+              "user-access-control"
+            ]
+          },
+          "subGroups": [
+            {
+              "id": "324fd704-c61c-41cf-8840-846d8d77e1c0",
+              "name": "Managers",
+              "path": "/REAL Customer Support Global/TESTING Customer Support/Managers",
+              "attributes": {
+                "allowed_application_ids": [
+                  "management-groups"
+                ]
+              },
+              "realmRoles": [],
+              "clientRoles": {
+                "management-groups": [
+                  "user-access-control"
+                ]
+              },
+              "subGroups": []
+            }
+          ]
+        },
+        {
+          "id": "9b238435-e1c1-4153-90f7-70b29519445c",
+          "name": "Customer Support FR",
+          "path": "/REAL Customer Support Global/Customer Support FR",
+          "attributes": {
+            "zone_codes": [
+              "Paris"
+            ],
+            "environments": [
+              "production"
+            ],
+            "allowed_application_ids": [
+              "unset"
+            ],
+            "fleet_ids": [
+              "1"
+            ],
+            "client_ids": [
+              "any"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {
+            "stuart-mc-package-app": [
+              "user-access-control"
+            ]
+          },
+          "subGroups": [
+            {
+              "id": "aec30f8b-6f2f-45eb-a66c-3476c363073f",
+              "name": "Managers",
+              "path": "/REAL Customer Support Global/Customer Support FR/Managers",
+              "attributes": {},
+              "realmRoles": [],
+              "clientRoles": {
+                "management-groups": [
+                  "user-access-control"
+                ]
+              },
+              "subGroups": []
+            },
+            {
+              "id": "89d7431a-e916-47b2-8896-86b70b425aaf",
+              "name": "Pontica - Supervisor and Shift Leads FR ",
+              "path": "/REAL Customer Support Global/Customer Support FR/Pontica - Supervisor and Shift Leads FR ",
+              "attributes": {
+                "zone_codes": [
+                  "unset"
+                ],
+                "environments": [
+                  "production"
+                ],
+                "fleet_ids": [
+                  "unset"
+                ],
+                "allowed_application_ids": [
+                  "unset"
+                ],
+                "client_ids": [
+                  "unset"
+                ]
+              },
+              "realmRoles": [],
+              "clientRoles": {},
+              "subGroups": [
+                {
+                  "id": "baf16d44-7b8c-4b69-bc1f-ac7e2e847617",
+                  "name": "Managers",
+                  "path": "/REAL Customer Support Global/Customer Support FR/Pontica - Supervisor and Shift Leads FR /Managers",
+                  "attributes": {},
+                  "realmRoles": [],
+                  "clientRoles": {
+                    "management-groups": [
+                      "user-access-control"
+                    ]
+                  },
+                  "subGroups": []
+                }
+              ]
+            },
+            {
+              "id": "c74376d8-8400-40f8-a799-d60d3d839c40",
+              "name": "Pontica - Admin Team Pontica  FR",
+              "path": "/REAL Customer Support Global/Customer Support FR/Pontica - Admin Team Pontica  FR",
+              "attributes": {
+                "zone_codes": [
+                  "Paris"
+                ],
+                "environments": [
+                  "production"
+                ],
+                "fleet_ids": [
+                  "1"
+                ],
+                "allowed_application_ids": [
+                  "unset"
+                ],
+                "client_ids": [
+                  "any"
+                ]
+              },
+              "realmRoles": [],
+              "clientRoles": {
+                "stuart-mc-package-app": [
+                  "user-access-control"
+                ]
+              },
+              "subGroups": [
+                {
+                  "id": "40d0bcdf-b8ea-46a5-9be1-b8846b82eac1",
+                  "name": "Managers",
+                  "path": "/REAL Customer Support Global/Customer Support FR/Pontica - Admin Team Pontica  FR/Managers",
+                  "attributes": {},
+                  "realmRoles": [],
+                  "clientRoles": {
+                    "management-groups": [
+                      "user-access-control"
+                    ]
+                  },
+                  "subGroups": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "fdbe545d-a6b6-40f2-9e8d-fddf2f0a91bf",
+          "name": "Apple Monitoring UK",
+          "path": "/REAL Customer Support Global/Apple Monitoring UK",
+          "attributes": {
+            "zone_codes": [
+              "any"
+            ],
+            "environments": [
+              "production"
+            ],
+            "fleet_ids": [
+              "any"
+            ],
+            "allowed_application_ids": [
+              "stuart-mc-package-app"
+            ],
+            "client_ids": [
+              "132403"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {
+            "stuart-mc-package-app": [
+              "user-access-control"
+            ]
+          },
+          "subGroups": [
+            {
+              "id": "1a6a0579-379a-4635-a451-b7c0e2399b0e",
+              "name": "Managers",
+              "path": "/REAL Customer Support Global/Apple Monitoring UK/Managers",
+              "attributes": {
+                "allowed_application_ids": [
+                  "management_groups",
+                  "stuart-mc-package-app"
+                ]
+              },
+              "realmRoles": [],
+              "clientRoles": {
+                "management-groups": [
+                  "user-access-control"
+                ]
+              },
+              "subGroups": []
+            }
+          ]
+        },
+        {
+          "id": "9721a71f-d7fe-472c-837a-d7790ffa7a82",
+          "name": "Customer Support SM",
+          "path": "/REAL Customer Support Global/Customer Support SM",
+          "attributes": {
+            "environments": [
+              "production"
+            ],
+            "zone_codes": [
+              "any"
+            ],
+            "allowed_application_ids": [
+              "unset"
+            ],
+            "fleet_ids": [
+              "any"
+            ],
+            "client_ids": [
+              "any"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {
+            "stuart-mc-package-app": [
+              "user-access-control"
+            ]
+          },
+          "subGroups": [
+            {
+              "id": "eed14844-9196-4999-80ee-d466b8629930",
+              "name": "Managers",
+              "path": "/REAL Customer Support Global/Customer Support SM/Managers",
+              "attributes": {},
+              "realmRoles": [],
+              "clientRoles": {
+                "management-groups": [
+                  "user-access-control"
+                ]
+              },
+              "subGroups": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "f832e8ca-1d6f-402e-8004-b5bbd47de93e",
+      "name": "REAL Delivery Slots Admins",
+      "path": "/REAL Delivery Slots Admins",
+      "attributes": {
+        "environments": [
+          "production",
+          "sandbox",
+          "qa",
+          "ephemeral",
+          "beta",
+          "development"
+        ],
+        "zone_codes": [
+          "any"
+        ],
+        "fleet_ids": [
+          "any"
+        ],
+        "allowed_application_ids": [
+          "stuart-mc-package-app",
+          "delivery-slots"
+        ],
+        "client_ids": [
+          "any"
+        ]
+      },
+      "realmRoles": [],
+      "clientRoles": {
+        "delivery-slots": [
+          "user-access-control"
+        ]
+      },
+      "subGroups": [
+        {
+          "id": "e7393585-a7fc-4934-b3d2-49540d74e279",
+          "name": "AM01",
+          "path": "/REAL Delivery Slots Admins/AM01",
+          "attributes": {
+            "environments": [
+              "production",
+              "sandbox",
+              "qa",
+              "ephemeral",
+              "beta",
+              "development"
+            ],
+            "zone_codes": [
+              "any"
+            ],
+            "fleet_ids": [
+              "any"
+            ],
+            "allowed_application_ids": [
+              "unset"
+            ],
+            "client_ids": [
+              "39663"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {},
+          "subGroups": [
+            {
+              "id": "a3c3417a-4354-4f57-bf52-22fa22cc939a",
+              "name": "Managers",
+              "path": "/REAL Delivery Slots Admins/AM01/Managers",
+              "attributes": {},
+              "realmRoles": [],
+              "clientRoles": {
+                "management-groups": [
+                  "user-access-control"
+                ]
+              },
+              "subGroups": []
+            }
+          ]
+        },
+        {
+          "id": "a6c804ed-7f25-4312-a78e-663b592b3bf2",
+          "name": "Managers",
+          "path": "/REAL Delivery Slots Admins/Managers",
+          "attributes": {
+            "allowed_application_ids": [
+              "management_groups",
+              "stuart-mc-package-app",
+              "delivery-slots"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {
+            "management-groups": [
+              "user-access-control"
+            ]
+          },
+          "subGroups": []
+        }
+      ]
+    },
+    {
+      "id": "f37643fe-01b9-4d83-87cb-4857e82c2fa9",
+      "name": "Stuart Dev Platform",
+      "path": "/Stuart Dev Platform",
+      "attributes": {
+        "features": [
+          "packageHistory",
+          "packageSearchCustomParams",
+          "featureFlags",
+          "dma",
+          "driverEarnings",
+          "pushFraudEstimations"
+        ],
+        "zone_codes": [
+          "any"
+        ],
+        "environments": [
+          "production",
+          "sandbox",
+          "qa",
+          "ephemeral",
+          "beta",
+          "development"
+        ],
+        "fleet_ids": [
+          "any"
+        ],
+        "allowed_application_ids": [
+          "stuart-mc-package-app",
+          "delivery-slots",
+          "stuart-poeta-visualization"
+        ],
+        "flags": [
+          "pii",
+          "preview",
+          "invisible"
+        ],
+        "client_ids": [
+          "any"
+        ]
+      },
+      "realmRoles": [],
+      "clientRoles": {
+        "stuart-mc-package-app": [
+          "user-access-control"
+        ]
+      },
+      "subGroups": [
+        {
+          "id": "f1af4aae-59f2-43ed-bac1-9e58eb222d22",
+          "name": "Managers",
+          "path": "/Stuart Dev Platform/Managers",
+          "attributes": {
+            "allowed_application_ids": [
+              "management-groups",
+              "stuart-mc-package-app",
+              "delivery-slots",
+              "stuart-poeta-visualization"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {
+            "management-groups": [
+              "user-access-control"
+            ],
+            "stuart-mc-package-app": [
+              "user-access-control"
+            ]
+          },
+          "subGroups": []
+        },
+        {
+          "id": "f794bdf7-9c1a-4792-a81c-c487682b787e",
+          "name": "test",
+          "path": "/Stuart Dev Platform/test",
+          "attributes": {
+            "features": [
+              "unset"
+            ],
+            "zone_codes": [
+              "unset"
+            ],
+            "environments": [
+              "unset"
+            ],
+            "fleet_ids": [
+              "unset"
+            ],
+            "allowed_application_ids": [
+              "unset"
+            ],
+            "flags": [
+              "unset"
+            ],
+            "client_ids": [
+              "unset"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {},
+          "subGroups": [
+            {
+              "id": "d09e24fb-3edc-44e4-bb7a-386e32d45dda",
+              "name": "Managers",
+              "path": "/Stuart Dev Platform/test/Managers",
+              "attributes": {},
+              "realmRoles": [],
+              "clientRoles": {
+                "management-groups": [
+                  "user-access-control"
+                ]
+              },
+              "subGroups": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "a1504061-8a22-4ab2-91a4-74005d14ef9a",
+      "name": "Stuart E2E",
+      "path": "/Stuart E2E",
+      "attributes": {
+        "zone_codes": [
+          "any"
+        ],
+        "allowed_application_ids": [
+          "stuart-mc-package-app"
+        ]
+      },
+      "realmRoles": [],
+      "clientRoles": {
+        "stuart-mc-package-app": [
+          "user-access-control"
+        ]
+      },
+      "subGroups": [
+        {
+          "id": "d57cb5f1-d81e-48c7-b253-a7059fe3f4c3",
+          "name": "QA 1",
+          "path": "/Stuart E2E/QA 1",
+          "attributes": {
+            "zone_codes": [
+              "unset"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {},
+          "subGroups": [
+            {
+              "id": "8e64b871-2a2f-4230-8573-57a4f3ef3ec3",
+              "name": "Managers",
+              "path": "/Stuart E2E/QA 1/Managers",
+              "attributes": {
+                "allowed_application_ids": [
+                  "management_groups",
+                  "stuart-mc-package-app"
+                ]
+              },
+              "realmRoles": [],
+              "clientRoles": {
+                "management-groups": [
+                  "user-access-control"
+                ]
+              },
+              "subGroups": []
+            }
+          ]
+        },
+        {
+          "id": "97cd0290-8ba4-46b6-acec-2f9f110a75c1",
+          "name": "Managers",
+          "path": "/Stuart E2E/Managers",
+          "attributes": {
+            "allowed_application_ids": [
+              "management_groups",
+              "stuart-mc-package-app"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {
+            "management-groups": [
+              "user-access-control"
+            ]
+          },
+          "subGroups": []
+        }
+      ]
+    },
+    {
+      "id": "65802567-1eac-4b1e-9d59-372ff7c5a4f4",
+      "name": "Stuart E2E 2",
+      "path": "/Stuart E2E 2",
+      "attributes": {
+        "features": [
+          "packageHistory",
+          "packageSearchCustomParams",
+          "featureFlags",
+          "dma",
+          "driverEarnings",
+          "pushFraudEstimations"
+        ],
+        "allowed_application_ids": [
+          "stuart-mc-package-app"
+        ]
+      },
+      "realmRoles": [],
+      "clientRoles": {
+        "stuart-mc-package-app": [
+          "user-access-control"
+        ]
+      },
+      "subGroups": [
+        {
+          "id": "976558ba-63ca-4a4f-bb15-d531597e2a04",
+          "name": "Managers",
+          "path": "/Stuart E2E 2/Managers",
+          "attributes": {
+            "allowed_application_ids": [
+              "management_groups",
+              "stuart-mc-package-app"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {
+            "management-groups": [
+              "user-access-control"
+            ]
+          },
+          "subGroups": []
+        }
+      ]
+    },
+    {
+      "id": "aee219bc-39c6-46e8-89fe-378d4e7e91ae",
+      "name": "TESTING ONLY Stuart France",
+      "path": "/TESTING ONLY Stuart France",
+      "attributes": {
+        "zone_codes": [
+          "aix_en_provence",
+          "amiens",
+          "angers",
+          "angouleme",
+          "annecy",
+          "antibes",
+          "arras",
+          "aubagne",
+          "avignon",
+          "bayonne",
+          "beauvais",
+          "belfort",
+          "besancon",
+          "bethune",
+          "beziers",
+          "blois",
+          "bordeaux",
+          "boulogne_sur_mer",
+          "bourges",
+          "brest",
+          "brive",
+          "caen",
+          "calais",
+          "cannes",
+          "carcassonne",
+          "cazeres",
+          "chalon_sur_saone",
+          "chalons_en_champagne",
+          "chambery",
+          "charleville_mezieres",
+          "chartres",
+          "cherbourg",
+          "cholet",
+          "clermont_ferrand",
+          "colmar",
+          "dieppe",
+          "dijon",
+          "dinard",
+          "douai",
+          "dunkerque",
+          "evreux",
+          "foix",
+          "frejus_saint_raphael",
+          "grenoble",
+          "guerande",
+          "hyeres",
+          "la_roche_sur_yon",
+          "la_rochelle",
+          "le_havre",
+          "le_mans",
+          "lens",
+          "lille",
+          "limoges",
+          "lorient",
+          "lyon",
+          "marseille",
+          "merignac",
+          "merlimont",
+          "metz",
+          "montauban",
+          "montpellier",
+          "mulhouse",
+          "nancy",
+          "nantes",
+          "narbonne",
+          "neydens",
+          "nice",
+          "nimes",
+          "niort",
+          "orleans",
+          "pamiers",
+          "paris",
+          "pau",
+          "perigueux",
+          "perpignan",
+          "poitiers",
+          "quimper",
+          "reims",
+          "rennes",
+          "roubaix",
+          "rouen",
+          "saint_brieuc",
+          "saint_etienne",
+          "saint_nazaire",
+          "saint_quentin",
+          "sedan",
+          "soissons",
+          "strasbourg",
+          "tarbes",
+          "thionville",
+          "toulon",
+          "toulouse",
+          "tours",
+          "troyes",
+          "valence",
+          "valenciennes",
+          "vannes"
+        ],
+        "environments": [
+          "production",
+          "sandbox",
+          "qa",
+          "ephemeral",
+          "beta",
+          "development"
+        ],
+        "fleet_ids": [
+          "any"
+        ],
+        "allowed_application_ids": [
+          "stuart-mc-package-app"
+        ],
+        "client_ids": [
+          "any"
+        ]
+      },
+      "realmRoles": [],
+      "clientRoles": {
+        "stuart-mc-package-app": [
+          "user-access-control"
+        ]
+      },
+      "subGroups": [
+        {
+          "id": "ed78820a-6003-46ab-b770-4c036ea33013",
+          "name": "City Operations",
+          "path": "/TESTING ONLY Stuart France/City Operations",
+          "attributes": {
+            "zone_codes": [
+              "paris"
+            ],
+            "environments": [
+              "production",
+              "sandbox",
+              "qa",
+              "ephemeral",
+              "beta",
+              "development"
+            ],
+            "fleet_ids": [
+              "any"
+            ],
+            "allowed_application_ids": [
+              "stuart-mc-package-app"
+            ],
+            "client_ids": [
+              "any"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {
+            "stuart-mc-package-app": [
+              "user-access-control"
+            ]
+          },
+          "subGroups": [
+            {
+              "id": "e9bb9ef1-dc9d-4032-9388-1159e2f80250",
+              "name": "Managers",
+              "path": "/TESTING ONLY Stuart France/City Operations/Managers",
+              "attributes": {
+                "allowed_application_ids": [
+                  "management_groups",
+                  "stuart-mc-package-app"
+                ]
+              },
+              "realmRoles": [],
+              "clientRoles": {
+                "management-groups": [
+                  "user-access-control"
+                ]
+              },
+              "subGroups": []
+            },
+            {
+              "id": "2b9d5966-0708-438d-9562-d7ebc47ad0f2",
+              "name": "City Operations Lyon",
+              "path": "/TESTING ONLY Stuart France/City Operations/City Operations Lyon",
+              "attributes": {
+                "zone_codes": [
+                  "paris"
+                ],
+                "environments": [
+                  "production",
+                  "sandbox",
+                  "qa",
+                  "ephemeral",
+                  "beta",
+                  "development"
+                ],
+                "fleet_ids": [
+                  "unset"
+                ],
+                "allowed_application_ids": [
+                  "stuart-mc-package-app"
+                ],
+                "client_ids": [
+                  "unset"
+                ]
+              },
+              "realmRoles": [],
+              "clientRoles": {
+                "stuart-mc-package-app": [
+                  "user-access-control"
+                ]
+              },
+              "subGroups": [
+                {
+                  "id": "4bbe26a1-5ac3-4fdc-9469-92cb48afa67d",
+                  "name": "Managers",
+                  "path": "/TESTING ONLY Stuart France/City Operations/City Operations Lyon/Managers",
+                  "attributes": {
+                    "allowed_application_ids": [
+                      "management_groups",
+                      "stuart-mc-package-app"
+                    ]
+                  },
+                  "realmRoles": [],
+                  "clientRoles": {
+                    "management-groups": [
+                      "user-access-control"
+                    ]
+                  },
+                  "subGroups": []
+                }
+              ]
+            },
+            {
+              "id": "c8822e7b-b9c1-4e8d-9cd6-ab7239cc9c61",
+              "name": "City Operations Paris",
+              "path": "/TESTING ONLY Stuart France/City Operations/City Operations Paris",
+              "attributes": {
+                "zone_codes": [
+                  "paris"
+                ],
+                "environments": [
+                  "production",
+                  "sandbox",
+                  "qa",
+                  "ephemeral",
+                  "beta",
+                  "development"
+                ],
+                "fleet_ids": [
+                  "any"
+                ],
+                "allowed_application_ids": [
+                  "stuart-mc-package-app"
+                ],
+                "client_ids": [
+                  "any"
+                ]
+              },
+              "realmRoles": [],
+              "clientRoles": {
+                "stuart-mc-package-app": [
+                  "user-access-control"
+                ]
+              },
+              "subGroups": [
+                {
+                  "id": "465c3c1e-790c-42b5-9fad-f5b95bd59cdb",
+                  "name": "Managers",
+                  "path": "/TESTING ONLY Stuart France/City Operations/City Operations Paris/Managers",
+                  "attributes": {
+                    "allowed_application_ids": [
+                      "management_groups",
+                      "stuart-mc-package-app"
+                    ]
+                  },
+                  "realmRoles": [],
+                  "clientRoles": {
+                    "management-groups": [
+                      "user-access-control"
+                    ]
+                  },
+                  "subGroups": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "c4da73a0-df76-45c3-a811-636123c32e2f",
+          "name": "Delivery Slot Managers test",
+          "path": "/TESTING ONLY Stuart France/Delivery Slot Managers test",
+          "attributes": {
+            "zone_codes": [
+              "any"
+            ],
+            "environments": [
+              "production",
+              "sandbox",
+              "qa",
+              "ephemeral",
+              "beta",
+              "development"
+            ],
+            "fleet_ids": [
+              "any"
+            ],
+            "allowed_application_ids": [
+              "stuart-mc-package-app"
+            ],
+            "client_ids": [
+              "any"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {
+            "delivery-slots": [
+              "user-access-control"
+            ]
+          },
+          "subGroups": [
+            {
+              "id": "782d75b3-2810-490c-af40-8f6a4a821370",
+              "name": "Managers",
+              "path": "/TESTING ONLY Stuart France/Delivery Slot Managers test/Managers",
+              "attributes": {
+                "allowed_application_ids": [
+                  "management_groups",
+                  "stuart-mc-package-app"
+                ]
+              },
+              "realmRoles": [],
+              "clientRoles": {
+                "management-groups": [
+                  "user-access-control"
+                ]
+              },
+              "subGroups": []
+            }
+          ]
+        },
+        {
+          "id": "603dd849-923f-4cc5-a126-91c12493baf5",
+          "name": "Courier Operations",
+          "path": "/TESTING ONLY Stuart France/Courier Operations",
+          "attributes": {
+            "zone_codes": [
+              "unset"
+            ],
+            "environments": [
+              "unset"
+            ],
+            "allowed_application_ids": [
+              "stuart-mc-package-app"
+            ],
+            "client_ids": [
+              "unset"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {},
+          "subGroups": [
+            {
+              "id": "c34a4613-3daa-482a-b040-79d36d96c87d",
+              "name": "Managers",
+              "path": "/TESTING ONLY Stuart France/Courier Operations/Managers",
+              "attributes": {
+                "allowed_application_ids": [
+                  "management_groups",
+                  "stuart-mc-package-app"
+                ]
+              },
+              "realmRoles": [],
+              "clientRoles": {
+                "management-groups": [
+                  "user-access-control"
+                ]
+              },
+              "subGroups": []
+            }
+          ]
+        },
+        {
+          "id": "785b93ec-899e-4eca-9596-0319bb2e97a5",
+          "name": "Product",
+          "path": "/TESTING ONLY Stuart France/Product",
+          "attributes": {
+            "zone_codes": [
+              "toulon",
+              "annecy",
+              "mulhouse",
+              "dunkerque",
+              "douai",
+              "valenciennes",
+              "beauvais",
+              "le_mans",
+              "roubaix",
+              "thionville",
+              "charleville_mezieres",
+              "cholet",
+              "saint_quentin",
+              "poitiers",
+              "colmar",
+              "besancon",
+              "soissons",
+              "arras",
+              "avignon",
+              "antibes",
+              "aubagne",
+              "valence",
+              "chambery",
+              "frejus_saint_raphael",
+              "perpignan",
+              "brest",
+              "pau",
+              "beziers",
+              "bayonne",
+              "vannes",
+              "bourges",
+              "blois",
+              "chartres",
+              "la_rochelle",
+              "quimper",
+              "pamiers",
+              "niort",
+              "merlimont",
+              "boulogne_sur_mer",
+              "foix",
+              "paris",
+              "lyon",
+              "bordeaux",
+              "toulouse",
+              "montpellier",
+              "limoges",
+              "nantes",
+              "perigueux",
+              "strasbourg",
+              "lille",
+              "grenoble",
+              "rennes",
+              "dijon",
+              "reims",
+              "amiens",
+              "nice",
+              "angouleme",
+              "brive",
+              "evreux",
+              "rouen",
+              "nancy",
+              "metz",
+              "le_havre",
+              "merignac",
+              "aix_en_provence",
+              "marseille",
+              "tours",
+              "orleans",
+              "clermont_ferrand",
+              "angers",
+              "caen",
+              "cannes",
+              "saint_etienne",
+              "nimes",
+              "calais"
+            ],
+            "environments": [
+              "production",
+              "sandbox",
+              "qa",
+              "ephemerals",
+              "beta",
+              "development"
+            ],
+            "fleet_ids": [
+              "any"
+            ],
+            "allowed_application_ids": [
+              "stuart-mc-package-app"
+            ],
+            "client_ids": [
+              "any"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {
+            "stuart-mc-package-app": [
+              "user-access-control"
+            ]
+          },
+          "subGroups": [
+            {
+              "id": "f018f7cd-406b-4a0a-91f7-0fa3794e49a6",
+              "name": "Managers",
+              "path": "/TESTING ONLY Stuart France/Product/Managers",
+              "attributes": {
+                "allowed_application_ids": [
+                  "management_groups",
+                  "stuart-mc-package-app"
+                ]
+              },
+              "realmRoles": [],
+              "clientRoles": {
+                "management-groups": [
+                  "user-access-control"
+                ]
+              },
+              "subGroups": []
+            },
+            {
+              "id": "7baf8d34-01d7-4978-800f-47252fcd2417",
+              "name": "Junior PM's",
+              "path": "/TESTING ONLY Stuart France/Product/Junior PM's",
+              "attributes": {
+                "zone_codes": [
+                  "unset"
+                ],
+                "environments": [
+                  "unset"
+                ],
+                "fleet_ids": [
+                  "unset"
+                ],
+                "allowed_application_ids": [
+                  "stuart-mc-package-app"
+                ],
+                "client_ids": [
+                  "unset"
+                ]
+              },
+              "realmRoles": [],
+              "clientRoles": {},
+              "subGroups": [
+                {
+                  "id": "7736f006-fb36-4b98-916a-1424f8855310",
+                  "name": "Managers",
+                  "path": "/TESTING ONLY Stuart France/Product/Junior PM's/Managers",
+                  "attributes": {
+                    "allowed_application_ids": [
+                      "management_groups",
+                      "stuart-mc-package-app"
+                    ]
+                  },
+                  "realmRoles": [],
+                  "clientRoles": {
+                    "management-groups": [
+                      "user-access-control"
+                    ]
+                  },
+                  "subGroups": []
+                }
+              ]
+            },
+            {
+              "id": "ea69c8e0-8541-448e-8828-8c8c4693657e",
+              "name": "Senior PM's",
+              "path": "/TESTING ONLY Stuart France/Product/Senior PM's",
+              "attributes": {
+                "zone_codes": [
+                  "unset"
+                ],
+                "environments": [
+                  "unset"
+                ],
+                "fleet_ids": [
+                  "unset"
+                ],
+                "allowed_application_ids": [
+                  "stuart-mc-package-app"
+                ],
+                "client_ids": [
+                  "unset"
+                ]
+              },
+              "realmRoles": [],
+              "clientRoles": {},
+              "subGroups": [
+                {
+                  "id": "0a082b9f-d097-4592-beae-a0f2dcb35594",
+                  "name": "Managers",
+                  "path": "/TESTING ONLY Stuart France/Product/Senior PM's/Managers",
+                  "attributes": {
+                    "allowed_application_ids": [
+                      "management_groups",
+                      "stuart-mc-package-app"
+                    ]
+                  },
+                  "realmRoles": [],
+                  "clientRoles": {
+                    "management-groups": [
+                      "user-access-control"
+                    ]
+                  },
+                  "subGroups": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "5680ff36-7fa3-4a34-8f6d-c311be7b88c7",
+          "name": "Managers",
+          "path": "/TESTING ONLY Stuart France/Managers",
+          "attributes": {
+            "allowed_application_ids": [
+              "management_groups",
+              "stuart-mc-package-app"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {
+            "management-groups": [
+              "user-access-control"
+            ]
+          },
+          "subGroups": []
+        },
+        {
+          "id": "38c6171c-c7a4-4c55-9626-a5918f618ec1",
+          "name": "Account Management",
+          "path": "/TESTING ONLY Stuart France/Account Management",
+          "attributes": {
+            "zone_codes": [
+              "unset"
+            ],
+            "environments": [
+              "unset"
+            ],
+            "allowed_application_ids": [
+              "stuart-mc-package-app"
+            ],
+            "client_ids": [
+              "unset"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {},
+          "subGroups": [
+            {
+              "id": "8e42391e-4cac-423d-b9b7-f24acd88c208",
+              "name": "Managers",
+              "path": "/TESTING ONLY Stuart France/Account Management/Managers",
+              "attributes": {
+                "allowed_application_ids": [
+                  "management_groups",
+                  "stuart-mc-package-app"
+                ]
+              },
+              "realmRoles": [],
+              "clientRoles": {
+                "management-groups": [
+                  "user-access-control"
+                ]
+              },
+              "subGroups": []
+            }
+          ]
+        },
+        {
+          "id": "d12b76c7-d30f-44e0-bc28-f50c8a4a593c",
+          "name": "helloTest",
+          "path": "/TESTING ONLY Stuart France/helloTest",
+          "attributes": {
+            "zone_codes": [
+              "unset"
+            ],
+            "environments": [
+              "unset"
+            ],
+            "fleet_ids": [
+              "unset"
+            ],
+            "allowed_application_ids": [
+              "unset"
+            ],
+            "client_ids": [
+              "unset"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {},
+          "subGroups": [
+            {
+              "id": "08d6fcbb-d422-4966-9561-3b0ac44ed716",
+              "name": "Managers",
+              "path": "/TESTING ONLY Stuart France/helloTest/Managers",
+              "attributes": {},
+              "realmRoles": [],
+              "clientRoles": {
+                "management-groups": [
+                  "user-access-control"
+                ]
+              },
+              "subGroups": []
+            }
+          ]
+        },
+        {
+          "id": "b0601f3c-0f49-4609-a57d-c958c63a1e17",
+          "name": "Product Analyst",
+          "path": "/TESTING ONLY Stuart France/Product Analyst",
+          "attributes": {
+            "zone_codes": [
+              "aix_en_provence",
+              "marseille",
+              "tours",
+              "orleans",
+              "clermont_ferrand",
+              "angers",
+              "caen",
+              "cannes",
+              "saint_etienne",
+              "nimes",
+              "calais",
+              "toulon",
+              "annecy",
+              "mulhouse",
+              "dunkerque",
+              "douai",
+              "valenciennes",
+              "beauvais",
+              "le_mans",
+              "roubaix",
+              "thionville",
+              "charleville_mezieres",
+              "cholet",
+              "saint_quentin",
+              "poitiers",
+              "colmar",
+              "besancon",
+              "soissons",
+              "arras",
+              "avignon",
+              "antibes",
+              "aubagne",
+              "valence",
+              "chambery",
+              "frejus_saint_raphael",
+              "perpignan",
+              "brest",
+              "pau",
+              "beziers",
+              "bayonne",
+              "vannes",
+              "bourges",
+              "blois",
+              "chartres",
+              "la_rochelle",
+              "quimper",
+              "pamiers",
+              "niort",
+              "merlimont",
+              "boulogne_sur_mer",
+              "foix",
+              "paris",
+              "lyon",
+              "bordeaux",
+              "toulouse",
+              "montpellier",
+              "limoges",
+              "nantes",
+              "perigueux",
+              "strasbourg",
+              "lille",
+              "grenoble",
+              "rennes",
+              "dijon",
+              "reims",
+              "amiens",
+              "nice",
+              "angouleme",
+              "brive",
+              "evreux",
+              "rouen",
+              "nancy",
+              "metz",
+              "le_havre",
+              "merignac"
+            ],
+            "environments": [
+              "unset"
+            ],
+            "fleet_ids": [
+              "any"
+            ],
+            "allowed_application_ids": [
+              "stuart-mc-package-app"
+            ],
+            "client_ids": [
+              "any"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {
+            "stuart-mc-package-app": [
+              "user-access-control"
+            ]
+          },
+          "subGroups": [
+            {
+              "id": "97a7923d-c61f-4489-8456-808be1368785",
+              "name": "Managers",
+              "path": "/TESTING ONLY Stuart France/Product Analyst/Managers",
+              "attributes": {
+                "allowed_application_ids": [
+                  "management_groups",
+                  "stuart-mc-package-app"
+                ]
+              },
+              "realmRoles": [],
+              "clientRoles": {
+                "management-groups": [
+                  "user-access-control"
+                ]
+              },
+              "subGroups": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "7b758292-1779-46dd-8ec9-774dd43ab74f",
+      "name": "TESTING ONLY Stuart Spain",
+      "path": "/TESTING ONLY Stuart Spain",
+      "attributes": {
+        "zone_codes": [
+          "girona",
+          "madrid",
+          "malaga",
+          "sevilla",
+          "valencia",
+          "valles",
+          "zaragoza",
+          "barcelona",
+          "bilbao"
+        ],
+        "environments": [
+          "production",
+          "sandbox",
+          "qa",
+          "ephemeral",
+          "beta",
+          "development"
+        ],
+        "fleet_ids": [
+          "any"
+        ],
+        "allowed_application_ids": [
+          "stuart-mc-package-app"
+        ],
+        "client_ids": [
+          "any"
+        ]
+      },
+      "realmRoles": [],
+      "clientRoles": {
+        "stuart-mc-package-app": [
+          "user-access-control"
+        ]
+      },
+      "subGroups": [
+        {
+          "id": "a81d3d04-487f-44e9-861c-bc14c932f7e2",
+          "name": "TEST Designers",
+          "path": "/TESTING ONLY Stuart Spain/TEST Designers",
+          "attributes": {
+            "zone_codes": [
+              "any"
+            ],
+            "environments": [
+              "production"
+            ],
+            "fleet_ids": [
+              "any"
+            ],
+            "allowed_application_ids": [
+              "unset"
+            ],
+            "client_ids": [
+              "any"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {},
+          "subGroups": [
+            {
+              "id": "12b33c9d-3c73-4579-92f0-8defb180ec5d",
+              "name": "TEST Designers Sub Group",
+              "path": "/TESTING ONLY Stuart Spain/TEST Designers/TEST Designers Sub Group",
+              "attributes": {
+                "zone_codes": [
+                  "unset"
+                ],
+                "environments": [
+                  "unset"
+                ],
+                "fleet_ids": [
+                  "unset"
+                ],
+                "allowed_application_ids": [
+                  "unset"
+                ],
+                "client_ids": [
+                  "unset"
+                ]
+              },
+              "realmRoles": [],
+              "clientRoles": {},
+              "subGroups": [
+                {
+                  "id": "1b5f4534-aa52-4dc2-bb59-65e72136db28",
+                  "name": "TEST Designers Sub Group Sub Group",
+                  "path": "/TESTING ONLY Stuart Spain/TEST Designers/TEST Designers Sub Group/TEST Designers Sub Group Sub Group",
+                  "attributes": {
+                    "zone_codes": [
+                      "unset"
+                    ],
+                    "environments": [
+                      "unset"
+                    ],
+                    "fleet_ids": [
+                      "unset"
+                    ],
+                    "allowed_application_ids": [
+                      "unset"
+                    ],
+                    "client_ids": [
+                      "unset"
+                    ]
+                  },
+                  "realmRoles": [],
+                  "clientRoles": {},
+                  "subGroups": [
+                    {
+                      "id": "d61602e6-caf0-4248-a0f6-b0e85ecfaa9f",
+                      "name": "Managers",
+                      "path": "/TESTING ONLY Stuart Spain/TEST Designers/TEST Designers Sub Group/TEST Designers Sub Group Sub Group/Managers",
+                      "attributes": {},
+                      "realmRoles": [],
+                      "clientRoles": {
+                        "management-groups": [
+                          "user-access-control"
+                        ]
+                      },
+                      "subGroups": []
+                    }
+                  ]
+                },
+                {
+                  "id": "b5e974be-44a8-41b8-bd6e-4d33f6c81563",
+                  "name": "Managers",
+                  "path": "/TESTING ONLY Stuart Spain/TEST Designers/TEST Designers Sub Group/Managers",
+                  "attributes": {},
+                  "realmRoles": [],
+                  "clientRoles": {
+                    "management-groups": [
+                      "user-access-control"
+                    ]
+                  },
+                  "subGroups": []
+                }
+              ]
+            },
+            {
+              "id": "227e408e-0ef8-44c0-88f0-f968368547ca",
+              "name": "Managers",
+              "path": "/TESTING ONLY Stuart Spain/TEST Designers/Managers",
+              "attributes": {},
+              "realmRoles": [],
+              "clientRoles": {
+                "management-groups": [
+                  "user-access-control"
+                ]
+              },
+              "subGroups": []
+            }
+          ]
+        },
+        {
+          "id": "f9fa2443-883e-4d2e-a8ac-6915da34da89",
+          "name": "Managers",
+          "path": "/TESTING ONLY Stuart Spain/Managers",
+          "attributes": {
+            "allowed_application_ids": [
+              "management_groups",
+              "stuart-mc-package-app"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {
+            "management-groups": [
+              "user-access-control"
+            ]
+          },
+          "subGroups": []
+        },
+        {
+          "id": "3b1d711d-0900-431f-b8dc-69e14482c5d6",
+          "name": "Live Operations",
+          "path": "/TESTING ONLY Stuart Spain/Live Operations",
+          "attributes": {
+            "zone_codes": [
+              "girona"
+            ],
+            "environments": [
+              "unset"
+            ],
+            "fleet_ids": [
+              "any"
+            ],
+            "allowed_application_ids": [
+              "stuart-mc-package-app"
+            ],
+            "client_ids": [
+              "any"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {
+            "stuart-mc-package-app": [
+              "user-access-control"
+            ]
+          },
+          "subGroups": [
+            {
+              "id": "ee2567d4-d8b3-47fe-9f8b-1087c926faf2",
+              "name": "Managers",
+              "path": "/TESTING ONLY Stuart Spain/Live Operations/Managers",
+              "attributes": {
+                "allowed_application_ids": [
+                  "management_groups",
+                  "stuart-mc-package-app"
+                ]
+              },
+              "realmRoles": [],
+              "clientRoles": {
+                "management-groups": [
+                  "user-access-control"
+                ]
+              },
+              "subGroups": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "1f237bd5-e08d-4c8c-9e0d-e53622eecda1",
+      "name": "TESTING ONLY Stuart UK",
+      "path": "/TESTING ONLY Stuart UK",
+      "attributes": {
+        "zone_codes": [
+          "basildon",
+          "birmingham",
+          "blackpool",
+          "bournemouth",
+          "brighton",
+          "bristol",
+          "cambridge",
+          "cardiff",
+          "darlington",
+          "derby",
+          "exeter",
+          "gillingham",
+          "grimsby",
+          "huddersfield",
+          "hull",
+          "leeds",
+          "leicester",
+          "liverpool",
+          "london",
+          "manchester",
+          "milton_keynes",
+          "newcastle_gateshead",
+          "northampton",
+          "nottingham",
+          "oxford",
+          "plymouth",
+          "reading",
+          "sheffield",
+          "south_shields",
+          "southampton",
+          "sunderland",
+          "swansea",
+          "teesside",
+          "wakefield",
+          "warrington"
+        ],
+        "environments": [
+          "production",
+          "sandbox",
+          "qa",
+          "ephemeral",
+          "beta",
+          "development"
+        ],
+        "fleet_ids": [
+          "any"
+        ],
+        "allowed_application_ids": [
+          "stuart-mc-package-app"
+        ],
+        "client_ids": [
+          "any"
+        ]
+      },
+      "realmRoles": [],
+      "clientRoles": {
+        "stuart-mc-package-app": [
+          "user-access-control"
+        ]
+      },
+      "subGroups": [
+        {
+          "id": "fe33d650-03f9-416e-b8f7-ec72c2c7c44d",
+          "name": "Operations",
+          "path": "/TESTING ONLY Stuart UK/Operations",
+          "attributes": {
+            "zone_codes": [
+              "southampton",
+              "northampton",
+              "swansea",
+              "reading",
+              "cardiff",
+              "gillingham",
+              "huddersfield",
+              "bournemouth",
+              "birmingham",
+              "blackpool",
+              "cambridge",
+              "brighton",
+              "warrington",
+              "leicester",
+              "milton_keynes",
+              "nottingham",
+              "london",
+              "newcastle_gateshead",
+              "south_shields",
+              "sunderland",
+              "darlington",
+              "teesside",
+              "leeds",
+              "sheffield",
+              "grimsby",
+              "bristol",
+              "liverpool",
+              "manchester",
+              "wakefield",
+              "derby",
+              "hull",
+              "oxford",
+              "plymouth",
+              "basildon",
+              "exeter"
+            ],
+            "environments": [
+              "unset"
+            ],
+            "fleet_ids": [
+              "any"
+            ],
+            "allowed_application_ids": [
+              "stuart-mc-package-app"
+            ],
+            "client_ids": [
+              "any"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {},
+          "subGroups": [
+            {
+              "id": "cc7df46e-70e2-427f-af6f-b698a06b78d5",
+              "name": "Managers",
+              "path": "/TESTING ONLY Stuart UK/Operations/Managers",
+              "attributes": {
+                "allowed_application_ids": [
+                  "management_groups",
+                  "stuart-mc-package-app"
+                ]
+              },
+              "realmRoles": [],
+              "clientRoles": {
+                "management-groups": [
+                  "user-access-control"
+                ]
+              },
+              "subGroups": []
+            }
+          ]
+        },
+        {
+          "id": "448a2831-ae36-4be8-932d-1604690cab0d",
+          "name": "Managers",
+          "path": "/TESTING ONLY Stuart UK/Managers",
+          "attributes": {
+            "allowed_application_ids": [
+              "management_groups",
+              "stuart-mc-package-app"
+            ]
+          },
+          "realmRoles": [],
+          "clientRoles": {
+            "management-groups": [
+              "user-access-control"
+            ]
+          },
+          "subGroups": []
+        }
+      ]
+    }
+  ],
+  "defaultRoles": [
+    "uma_authorization",
+    "offline_access"
+  ],
+  "requiredCredentials": [
+    "password"
+  ],
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpSupportedApplications": [
+    "FreeOTP",
+    "Google Authenticator"
+  ],
+  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicySignatureAlgorithms": [
+    "ES256"
+  ],
+  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyRequireResidentKey": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyCreateTimeout": 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+    "ES256"
+  ],
+  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout": 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "scopeMappings": [
+    {
+      "clientScope": "offline_access",
+      "roles": [
+        "offline_access"
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "id": "cd1b8f73-4ac4-4275-aa00-9401e3374a1d",
+      "name": "address",
+      "description": "OpenID Connect built-in scope: address",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${addressScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "e6e11ab6-510a-48b7-ab83-d1dc276aabc4",
+          "name": "address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-address-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute.formatted": "formatted",
+            "user.attribute.country": "country",
+            "user.attribute.postal_code": "postal_code",
+            "userinfo.token.claim": "true",
+            "user.attribute.street": "street",
+            "id.token.claim": "true",
+            "user.attribute.region": "region",
+            "access.token.claim": "true",
+            "user.attribute.locality": "locality"
+          }
+        }
+      ]
+    },
+    {
+      "id": "4d1b5f8e-99e3-47d1-b751-1fba11dc5a63",
+      "name": "email",
+      "description": "OpenID Connect built-in scope: email",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${emailScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "93f84bb2-4cbe-4e63-87ca-faf8cf7a98f3",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "3ac3835d-0385-485a-934d-8318b7c63c93",
+          "name": "email verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "emailVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email_verified",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "id": "3a81dc05-583f-46fa-b905-64abd24e47c1",
+      "name": "graphql",
+      "description": "Carries the GraphQL permission schema attribute mappers",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "c2f5ced0-8dae-4c4b-98e5-583b1ccd8054",
+          "name": "admin_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "false",
+            "user.attribute": "admin_id",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:admin_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "103bf575-9b5e-4f70-9075-c869e2e92a92",
+          "name": "environments",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "aggregate.attrs": "true",
+            "multivalued": "true",
+            "userinfo.token.claim": "false",
+            "user.attribute": "environments",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:environments",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d7d51a9c-2603-4c07-a2a2-d317fec88a09",
+          "name": "zone_codes",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "aggregate.attrs": "true",
+            "multivalued": "true",
+            "userinfo.token.claim": "false",
+            "user.attribute": "zone_codes",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:zone_codes",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "4e3ff890-a8c0-420b-9cea-23828271c92f",
+          "name": "fleet_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "aggregate.attrs": "true",
+            "multivalued": "true",
+            "userinfo.token.claim": "false",
+            "user.attribute": "fleet_ids",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:fleet_ids",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "736ff81d-844c-42d5-883b-90215c998e96",
+          "name": "client_ids",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "aggregate.attrs": "true",
+            "multivalued": "true",
+            "userinfo.token.claim": "false",
+            "user.attribute": "client_ids",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_ids",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "e46d998f-bde4-4512-b86d-c799e24cc26b",
+          "name": "client_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "false",
+            "user.attribute": "client_id",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "64db4f49-daf4-4c6c-9cc3-d1a31c982329",
+          "name": "driver_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "aggregate.attrs": "false",
+            "multivalued": "false",
+            "userinfo.token.claim": "false",
+            "user.attribute": "driver_id",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:driver_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "be88ed15-d857-4a25-bae4-4cac5ecaa992",
+          "name": "idp",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "false",
+            "user.attribute": "idp",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:idp",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "da1c8819-51d5-44fe-9377-ad31b3afa080",
+          "name": "flags",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "false",
+            "multivalued": "true",
+            "user.attribute": "flags",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:flags",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "53cc28d7-0f05-4f5e-a2da-e3c0fa1f2e7d",
+          "name": "features",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "false",
+            "multivalued": "true",
+            "user.attribute": "features",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:features",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "a98b4f4a-e242-4cfc-b466-d6963bbb588d",
+      "name": "microprofile-jwt",
+      "description": "Microprofile - JWT built-in scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "357535e0-a1af-40fa-9238-c42655f31332",
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "multivalued": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "bfb84423-a302-49df-909c-b2d577f32733",
+          "name": "upn",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "upn",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "b72c88c2-f76f-47bb-b225-f6d68762d62a",
+      "name": "offline_access",
+      "description": "OpenID Connect built-in scope: offline_access",
+      "protocol": "openid-connect",
+      "attributes": {
+        "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "id": "456badf7-98e5-418f-81b4-7381d9f621f3",
+      "name": "phone",
+      "description": "OpenID Connect built-in scope: phone",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${phoneScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "b1ff5727-80d9-46d9-8ad2-28928364634d",
+          "name": "phone number",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumber",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "0d5d733f-eedf-4402-a9e8-5015436be8f4",
+          "name": "phone number verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumberVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number_verified",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "id": "5512022e-e817-4e36-b288-0bd7866cc9ea",
+      "name": "profile",
+      "description": "OpenID Connect built-in scope: profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${profileScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "1e4a1a36-8ffa-448f-81c5-72c1be496ea4",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "7f2b4195-8685-4c4d-8cbc-3e837b84daa1",
+          "name": "gender",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "gender",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "gender",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "a90f97bb-22eb-46b6-9668-d9980a927a52",
+          "name": "nickname",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "nickname",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "nickname",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c24512a0-76a1-40b2-8681-135e152c36d3",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "299e423c-4e16-4e83-8e07-05731daaa6b9",
+          "name": "picture",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "picture",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "picture",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "948d2795-2982-4e53-9147-21c67267f95a",
+          "name": "middle name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "middleName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "middle_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "0abdd2d5-c8b6-41ee-aaa4-020cd6d1ab57",
+          "name": "birthdate",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "birthdate",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "birthdate",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "7071871c-7310-473b-be95-5f923979cf62",
+          "name": "updated at",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "updatedAt",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "updated_at",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "5803a398-0a70-4974-9bb0-db1347923f3e",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c2b1bcda-be94-474d-af10-90eff2ae7451",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ac1b0b3f-e5d7-4884-a6bd-42a842443276",
+          "name": "profile",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "profile",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "profile",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "fef5d358-d29c-4641-9e95-6828ffa7a825",
+          "name": "website",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "website",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "website",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "6ad7c82a-6ec3-4208-89e2-9d3f696abe3c",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "c1b6ad45-4789-4656-8efb-a470a872b6f7",
+          "name": "zoneinfo",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "zoneinfo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "zoneinfo",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "0bb235ae-a789-47b5-ad3b-1883b45225f0",
+      "name": "role_list",
+      "description": "SAML role list",
+      "protocol": "saml",
+      "attributes": {
+        "consent.screen.text": "${samlRoleListScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "b8ce7cf3-fe12-4016-80e2-253c5f9c8d34",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        }
+      ]
+    },
+    {
+      "id": "8068afab-0c65-4b07-b3be-b8ef6be169f9",
+      "name": "roles",
+      "description": "OpenID Connect scope for add user roles to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "${rolesScopeConsentText}"
+      },
+      "protocolMappers": [
+        {
+          "id": "12251252-d119-45ba-9c9c-31cfcbcff006",
+          "name": "client roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "resource_access.${client_id}.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "0d4ee838-4651-49f8-a37c-4453a69882bd",
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "f9959649-534d-4c75-ad60-e982f5233282",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ]
+    },
+    {
+      "id": "27ce23a0-f7b5-4a4a-8f61-47bd83a9e328",
+      "name": "web-origins",
+      "description": "OpenID Connect scope for add allowed web origins to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false",
+        "consent.screen.text": ""
+      },
+      "protocolMappers": [
+        {
+          "id": "66039beb-7c4b-4cfa-9df0-2edab5386c08",
+          "name": "allowed web origins",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-allowed-origins-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ]
+    },
+    {
+      "id": "3ed4016b-bd7d-41a2-916d-158450fa0ef4",
+      "name": "driver:identity",
+      "description": "Allow app to request putting driver ID specifics in the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "true",
+        "consent.screen.text": "This app would like to read your driver identity."
+      },
+      "protocolMappers": [
+        {
+          "id": "7250dd2e-63cc-4466-8cf6-95d7bf41da2c",
+          "name": "srt:driver_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "false",
+            "user.attribute": "driver_id",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:driver_id",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "53895eb2-57e8-4f79-b984-d7430ea0dd42",
+      "name": "client_local",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "a036330a-951f-48de-9a3d-3288b2656cbf",
+          "name": "srt:client_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "9",
+            "userinfo.token.claim": "false",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "claim.name": "srt:client_id",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "role_list",
+    "profile",
+    "email",
+    "roles",
+    "web-origins"
+  ],
+  "defaultOptionalClientScopes": [
+    "offline_access",
+    "address",
+    "phone",
+    "microprofile-jwt"
+  ],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection": "1; mode=block",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer": {},
+  "loginTheme": "stuartdefault",
+  "eventsEnabled": true,
+  "eventsListeners": [
+    "jboss-logging"
+  ],
+  "enabledEventTypes": [
+    "SEND_RESET_PASSWORD",
+    "UPDATE_CONSENT_ERROR",
+    "GRANT_CONSENT",
+    "REMOVE_TOTP",
+    "REVOKE_GRANT",
+    "UPDATE_TOTP",
+    "LOGIN_ERROR",
+    "CLIENT_LOGIN",
+    "RESET_PASSWORD_ERROR",
+    "IMPERSONATE_ERROR",
+    "CODE_TO_TOKEN_ERROR",
+    "CUSTOM_REQUIRED_ACTION",
+    "RESTART_AUTHENTICATION",
+    "IMPERSONATE",
+    "UPDATE_PROFILE_ERROR",
+    "LOGIN",
+    "UPDATE_PASSWORD_ERROR",
+    "CLIENT_INITIATED_ACCOUNT_LINKING",
+    "TOKEN_EXCHANGE",
+    "LOGOUT",
+    "REGISTER",
+    "CLIENT_REGISTER",
+    "IDENTITY_PROVIDER_LINK_ACCOUNT",
+    "UPDATE_PASSWORD",
+    "CLIENT_DELETE",
+    "FEDERATED_IDENTITY_LINK_ERROR",
+    "IDENTITY_PROVIDER_FIRST_LOGIN",
+    "CLIENT_DELETE_ERROR",
+    "VERIFY_EMAIL",
+    "CLIENT_LOGIN_ERROR",
+    "RESTART_AUTHENTICATION_ERROR",
+    "EXECUTE_ACTIONS",
+    "REMOVE_FEDERATED_IDENTITY_ERROR",
+    "TOKEN_EXCHANGE_ERROR",
+    "PERMISSION_TOKEN",
+    "SEND_IDENTITY_PROVIDER_LINK_ERROR",
+    "EXECUTE_ACTION_TOKEN_ERROR",
+    "SEND_VERIFY_EMAIL",
+    "EXECUTE_ACTIONS_ERROR",
+    "REMOVE_FEDERATED_IDENTITY",
+    "IDENTITY_PROVIDER_POST_LOGIN",
+    "IDENTITY_PROVIDER_LINK_ACCOUNT_ERROR",
+    "UPDATE_EMAIL",
+    "REGISTER_ERROR",
+    "REVOKE_GRANT_ERROR",
+    "EXECUTE_ACTION_TOKEN",
+    "LOGOUT_ERROR",
+    "UPDATE_EMAIL_ERROR",
+    "CLIENT_UPDATE_ERROR",
+    "UPDATE_PROFILE",
+    "CLIENT_REGISTER_ERROR",
+    "FEDERATED_IDENTITY_LINK",
+    "SEND_IDENTITY_PROVIDER_LINK",
+    "SEND_VERIFY_EMAIL_ERROR",
+    "RESET_PASSWORD",
+    "CLIENT_INITIATED_ACCOUNT_LINKING_ERROR",
+    "UPDATE_CONSENT",
+    "REMOVE_TOTP_ERROR",
+    "VERIFY_EMAIL_ERROR",
+    "SEND_RESET_PASSWORD_ERROR",
+    "CLIENT_UPDATE",
+    "CUSTOM_REQUIRED_ACTION_ERROR",
+    "IDENTITY_PROVIDER_POST_LOGIN_ERROR",
+    "UPDATE_TOTP_ERROR",
+    "CODE_TO_TOKEN",
+    "GRANT_CONSENT_ERROR",
+    "IDENTITY_PROVIDER_FIRST_LOGIN_ERROR"
+  ],
+  "adminEventsEnabled": true,
+  "adminEventsDetailsEnabled": false,
+  "identityProviders": [
+    {
+      "alias": "pontica",
+      "displayName": "Google from Pontica",
+      "internalId": "6f48af48-b1a7-4c0c-ae6c-ef9b8c2da048",
+      "providerId": "oidc",
+      "enabled": true,
+      "updateProfileFirstLoginMode": "on",
+      "trustEmail": true,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "authenticateByDefault": false,
+      "linkOnly": false,
+      "firstBrokerLoginFlowAlias": "first broker login",
+      "postBrokerLoginFlowAlias": "Client Access Authenticator",
+      "config": {
+        "hideOnLoginPage": "false",
+        "validateSignature": "",
+        "userInfoUrl": "https://openidconnect.googleapis.com/v1/userinfo",
+        "uiLocales": "",
+        "acceptsPromptNoneForwardFromClient": "",
+        "tokenUrl": "https://oauth2.googleapis.com/token",
+        "clientId": "105908661118-0vr0h5ho7518unl3p00vvjgo4ll5vjan.apps.googleusercontent.com",
+        "backchannelSupported": "",
+        "issuer": "https://accounts.google.com",
+        "useJwksUrl": "true",
+        "loginHint": "",
+        "authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth?hd=ponticasolutions.com",
+        "clientAuthMethod": "client_secret_post",
+        "disableUserInfo": "",
+        "clientSecret": "**********",
+        "prompt": "",
+        "guiOrder": "2",
+        "defaultScope": "openid profile email"
+      }
+    },
+    {
+      "alias": "google",
+      "internalId": "543c4bf5-b51d-4056-9f4a-938cdd2d99ab",
+      "providerId": "google",
+      "enabled": true,
+      "updateProfileFirstLoginMode": "on",
+      "trustEmail": true,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "authenticateByDefault": false,
+      "linkOnly": false,
+      "firstBrokerLoginFlowAlias": "first broker login",
+      "postBrokerLoginFlowAlias": "Client Access Authenticator",
+      "config": {
+        "hideOnLoginPage": "",
+        "offlineAccess": "",
+        "acceptsPromptNoneForwardFromClient": "",
+        "clientId": "406759240425-tns0suq1ur38hre3ssdo0qerc9vhnqst.apps.googleusercontent.com",
+        "disableUserInfo": "",
+        "hostedDomain": "stuart.com",
+        "userIp": "",
+        "clientSecret": "**********",
+        "useJwksUrl": "true"
+      }
+    }
+  ],
+  "identityProviderMappers": [
+    {
+      "id": "822ca862-0975-42ed-8d55-0aef192a7733",
+      "name": "idp",
+      "identityProviderAlias": "google",
+      "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+      "config": {
+        "attribute.value": "google",
+        "attribute": "idp"
+      }
+    }
+  ],
+  "components": {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+      {
+        "id": "f778a489-2ac5-49e7-b591-54cefff26efd",
+        "name": "Trusted Hosts",
+        "providerId": "trusted-hosts",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "host-sending-registration-request-must-match": [
+            "true"
+          ],
+          "client-uris-must-match": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "0a1dd0af-9f5d-4303-bbf8-85cf4476cb76",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-usermodel-attribute-mapper",
+            "saml-user-attribute-mapper",
+            "saml-role-list-mapper",
+            "oidc-full-name-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "saml-user-property-mapper",
+            "oidc-address-mapper",
+            "oidc-usermodel-property-mapper"
+          ]
+        }
+      },
+      {
+        "id": "89efaec5-f573-4d4f-8800-9c0e35a6b50e",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "cc58da9d-a99b-4aad-963b-48e4a2c0798a",
+        "name": "Max Clients Limit",
+        "providerId": "max-clients",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "max-clients": [
+            "200"
+          ]
+        }
+      },
+      {
+        "id": "36547dca-c90d-4f58-866e-f85b541f9387",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "7fec7fac-ebd0-478b-9b62-aa8e41db43a7",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "saml-user-attribute-mapper",
+            "oidc-usermodel-property-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "saml-user-property-mapper",
+            "oidc-address-mapper",
+            "oidc-full-name-mapper",
+            "saml-role-list-mapper"
+          ]
+        }
+      },
+      {
+        "id": "1dac8e5a-d618-4926-afad-1303ae30cfc1",
+        "name": "Consent Required",
+        "providerId": "consent-required",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "b39b51e4-09f3-4af3-a8de-d3233836e33f",
+        "name": "Full Scope Disabled",
+        "providerId": "scope",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      }
+    ],
+    "org.keycloak.keys.KeyProvider": [
+      {
+        "id": "33239f9d-e793-451f-9d08-627ed1375daa",
+        "name": "fallback-HS256",
+        "providerId": "hmac-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "-100"
+          ],
+          "algorithm": [
+            "HS256"
+          ]
+        }
+      },
+      {
+        "id": "fb1c33a0-f2d3-4539-824c-16f3892e1c72",
+        "name": "ecdsa-generated",
+        "providerId": "ecdsa-generated",
+        "subComponents": {},
+        "config": {
+          "ecdsaEllipticCurveKey": [
+            "P-256"
+          ],
+          "active": [
+            "true"
+          ],
+          "priority": [
+            "0"
+          ],
+          "enabled": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "55eae381-7fcd-47ab-a740-b183545bcc38",
+        "name": "fallback-RS256",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "-100"
+          ],
+          "algorithm": [
+            "RS256"
+          ]
+        }
+      }
+    ]
+  },
+  "internationalizationEnabled": false,
+  "supportedLocales": [
+    ""
+  ],
+  "authenticationFlows": [
+    {
+      "id": "5d0d2ebe-7ae3-474a-ae35-3fdff1df8a46",
+      "alias": "Account verification options",
+      "description": "Method with which to verity the existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-email-verification",
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "flowAlias": "Verify Existing Account by Re-authentication",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "b75a3c2a-f5bc-4296-b191-ae04b9151250",
+      "alias": "Authentication Options",
+      "description": "Authentication options.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "basic-auth",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "basic-auth-otp",
+          "requirement": "DISABLED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "requirement": "DISABLED",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "f5662006-0277-4547-9837-e80686100b36",
+      "alias": "Browser",
+      "description": "",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "requirement": "ALTERNATIVE",
+          "priority": 0,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "requirement": "ALTERNATIVE",
+          "priority": 1,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-page-form",
+          "requirement": "ALTERNATIVE",
+          "priority": 2,
+          "flowAlias": "Form",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "adc721b2-765e-4560-a6c1-5697bf2272a1",
+      "alias": "Browser - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "cb587590-17dd-43a8-944f-7a2aed1ed0aa",
+      "alias": "Browser With User Access Verification",
+      "description": "browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "requirement": "REQUIRED",
+          "priority": 31,
+          "flowAlias": "Browser",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        },
+        {
+          "authenticator": "script-client-authenticator.js",
+          "requirement": "REQUIRED",
+          "priority": 32,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "5d07efb7-0151-4632-b77f-60a82011c23f",
+      "alias": "Client Access Authenticator",
+      "description": "",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "script-client-authenticator.js",
+          "requirement": "REQUIRED",
+          "priority": 0,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "b3224ba1-ca2d-4470-909b-fa3e97c18499",
+      "alias": "Direct Grant - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "direct-grant-validate-otp",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "753c6467-3fe1-4068-9797-b45920e3a99e",
+      "alias": "First broker login - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "0decf3cb-7ac3-43d6-b3c0-79b8fe66e144",
+      "alias": "Form",
+      "description": "",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": false,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "requirement": "REQUIRED",
+          "priority": 0,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "446f2dcc-cd84-4d3d-832d-ecdefe38702c",
+      "alias": "Handle Existing Account",
+      "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-confirm-link",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "flowAlias": "Account verification options",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "dca943a1-baa1-4b9c-ba21-004a3c8d6129",
+      "alias": "Reset - Conditional OTP",
+      "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "reset-otp",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "05589f17-2167-402e-97ba-6ed9ec1b5c21",
+      "alias": "User creation or linking",
+      "description": "Flow for the existing/non-existing user alternatives",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "create unique user config",
+          "authenticator": "idp-create-user-if-unique",
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "flowAlias": "Handle Existing Account",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "c1a6c049-8b1c-4258-9ed9-92a3515f9cb5",
+      "alias": "Verify Existing Account by Re-authentication",
+      "description": "Reauthentication of existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-username-password-form",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "flowAlias": "First broker login - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "48620dfa-7d8d-400d-8112-b8231bcc2927",
+      "alias": "browser",
+      "description": "browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "requirement": "DISABLED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "flowAlias": "forms",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "5a76108b-bc1c-4f5d-89f8-7d5d601d91d9",
+      "alias": "clients",
+      "description": "Base authentication for clients",
+      "providerId": "client-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "client-secret",
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "client-jwt",
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "client-secret-jwt",
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "client-x509",
+          "requirement": "ALTERNATIVE",
+          "priority": 40,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "f8a257a0-b734-46a5-8c85-c54b03e74a23",
+      "alias": "direct grant",
+      "description": "OpenID Connect Resource Owner Grant",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "direct-grant-validate-username",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "direct-grant-validate-password",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "CONDITIONAL",
+          "priority": 30,
+          "flowAlias": "Direct Grant - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "2c2205af-536d-44ca-bcdc-ce1239ecf1f6",
+      "alias": "docker auth",
+      "description": "Used by Docker clients to authenticate against the IDP",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "8cd65670-e350-4004-b181-920839676ce6",
+      "alias": "first broker login",
+      "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "review profile config",
+          "authenticator": "idp-review-profile",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "flowAlias": "User creation or linking",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "ca5ba922-5c8d-4dd4-a421-9a9ac31e22ce",
+      "alias": "forms",
+      "description": "Username, password, otp and other auth forms.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "flowAlias": "Browser - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "ced3b856-80fe-4939-b173-a099282f98e6",
+      "alias": "http challenge",
+      "description": "An authentication flow based on challenge-response HTTP Authentication Schemes",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "no-cookie-redirect",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "flowAlias": "Authentication Options",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "24d66d4f-88e4-4ef7-b310-4a5d08b084b3",
+      "alias": "registration",
+      "description": "registration flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "flowAlias": "registration form",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "489aedd6-f889-4bad-b7d6-853bcdbd4fad",
+      "alias": "registration form",
+      "description": "registration form",
+      "providerId": "form-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-user-creation",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-profile-action",
+          "requirement": "REQUIRED",
+          "priority": 40,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-password-action",
+          "requirement": "REQUIRED",
+          "priority": 50,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-recaptcha-action",
+          "requirement": "DISABLED",
+          "priority": 60,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "960f3fce-7ee7-4ded-985b-0cf7f709b089",
+      "alias": "reset credentials",
+      "description": "Reset credentials for a user if they forgot their password or something",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "reset-credentials-choose-user",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "reset-credential-email",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "reset-password",
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "CONDITIONAL",
+          "priority": 40,
+          "flowAlias": "Reset - Conditional OTP",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "dc081de8-9b1d-40c5-b712-183bbef5a448",
+      "alias": "saml ecp",
+      "description": "SAML ECP Profile Authentication Flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "http-basic-authenticator",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "id": "81d487e6-b3ad-462b-9f30-527c32f959fe",
+      "alias": "create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
+      }
+    },
+    {
+      "id": "e3c8db16-e690-4d25-bf9b-9f3c0c4c139d",
+      "alias": "group-manager",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "238f0f56-249b-4182-9078-a6d76f7b9809",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "2ffc6aff-bf69-4995-866e-6b630c502418",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "4ff2cd2c-7367-4c78-b11a-f97631ed8975",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "de8968d7-b600-446f-b81d-404d7e6e1000",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "9b1e6914-905d-48c3-8af2-7f0fd29898f7",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "4d42a886-6664-4350-954a-be9eef4cb718",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "abafdc79-eac6-4d80-b353-1e6fc6f48af6",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "29588348-335d-45c6-b596-ddd9a15f1f4e",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "717f6c75-c5f1-425b-9f4f-0213cf0abab5",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "ac455d62-13ec-4863-80f6-ca11f1b11b3d",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "86bc657a-5a8d-4547-af57-537c75340420",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "7fe80a0e-5c59-4789-a52a-9ef73a0e226c",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "2dd8dc94-9e4f-4c17-8c4e-a2ee073b90f4",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "7821f341-5c28-472e-9890-e446f1a36947",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "40d3f618-f19a-4412-9a9b-ea93fde42e8a",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "2d4879af-f12d-4535-81eb-d0466234b76e",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "893bc087-6e9a-48bc-8227-418010fe822b",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "1788dc9a-3435-4c8c-a72b-94a2e433bd0d",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "5a3829fe-561c-4d8d-bf6c-5e89a59e8556",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "6ae8333a-c371-4ceb-bf16-18ddd09411f6",
+      "alias": "groups-management",
+      "config": {
+        "condUserRole": "groups-management"
+      }
+    },
+    {
+      "id": "f5ae5140-f4b3-4543-978c-4c511c665467",
+      "alias": "groups-management.groups-management",
+      "config": {
+        "condUserRole": "terexa-test-ugm.groups-management"
+      }
+    },
+    {
+      "id": "6b9cf769-2880-4973-b9f4-b4832bb90cbc",
+      "alias": "review profile config",
+      "config": {
+        "update.profile.on.first.login": "missing"
+      }
+    },
+    {
+      "id": "ae9cf032-4ef4-4516-8a98-cc7dd4d62ea4",
+      "alias": "terexa-test-ugm.manager",
+      "config": {
+        "condUserRole": "terexa-test-ugm.manager"
+      }
+    }
+  ],
+  "requiredActions": [
+    {
+      "alias": "CONFIGURE_TOTP",
+      "name": "Configure OTP",
+      "providerId": "CONFIGURE_TOTP",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 10,
+      "config": {}
+    },
+    {
+      "alias": "terms_and_conditions",
+      "name": "Terms and Conditions",
+      "providerId": "terms_and_conditions",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 20,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PASSWORD",
+      "name": "Update Password",
+      "providerId": "UPDATE_PASSWORD",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 30,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PROFILE",
+      "name": "Update Profile",
+      "providerId": "UPDATE_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 40,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 50,
+      "config": {}
+    },
+    {
+      "alias": "update_user_locale",
+      "name": "Update User Locale",
+      "providerId": "update_user_locale",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 1000,
+      "config": {}
+    }
+  ],
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "attributes": {
+    "displayName": "Stuart",
+    "webAuthnPolicyAuthenticatorAttachment": "not specified",
+    "_browser_header.xRobotsTag": "none",
+    "webAuthnPolicyAttestationConveyancePreferencePasswordless": "not specified",
+    "webAuthnPolicyRequireResidentKeyPasswordless": "not specified",
+    "webAuthnPolicySignatureAlgorithmsPasswordless": "ES256",
+    "webAuthnPolicyRpEntityName": "keycloak",
+    "webAuthnPolicyAvoidSameAuthenticatorRegisterPasswordless": "false",
+    "failureFactor": "30",
+    "webAuthnPolicyAuthenticatorAttachmentPasswordless": "not specified",
+    "actionTokenGeneratedByUserLifespan": "300",
+    "maxDeltaTimeSeconds": "43200",
+    "webAuthnPolicySignatureAlgorithms": "ES256",
+    "webAuthnPolicyRpEntityNamePasswordless": "keycloak",
+    "offlineSessionMaxLifespan": "5184000",
+    "_browser_header.contentSecurityPolicyReportOnly": "",
+    "bruteForceProtected": "false",
+    "webAuthnPolicyRpIdPasswordless": "",
+    "actionTokenGeneratedByUserLifespan.reset-credentials": "300",
+    "_browser_header.contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "_browser_header.xXSSProtection": "1; mode=block",
+    "_browser_header.xFrameOptions": "SAMEORIGIN",
+    "_browser_header.strictTransportSecurity": "max-age=31536000; includeSubDomains",
+    "webAuthnPolicyUserVerificationRequirement": "not specified",
+    "permanentLockout": "false",
+    "quickLoginCheckMilliSeconds": "1000",
+    "webAuthnPolicyCreateTimeout": "0",
+    "webAuthnPolicyRequireResidentKey": "not specified",
+    "webAuthnPolicyRpId": "",
+    "webAuthnPolicyAttestationConveyancePreference": "not specified",
+    "maxFailureWaitSeconds": "900",
+    "minimumQuickLoginWaitSeconds": "60",
+    "defaultSignatureAlgorithm": "ES256",
+    "webAuthnPolicyCreateTimeoutPasswordless": "0",
+    "webAuthnPolicyAvoidSameAuthenticatorRegister": "false",
+    "webAuthnPolicyUserVerificationRequirementPasswordless": "not specified",
+    "_browser_header.xContentTypeOptions": "nosniff",
+    "actionTokenGeneratedByAdminLifespan": "43200",
+    "waitIncrementSeconds": "60",
+    "offlineSessionMaxLifespanEnabled": "false"
+  },
+  "keycloakVersion": "9.0.0",
+  "userManagedAccessAllowed": false
+}


### PR DESCRIPTION
Totally unattended init:

` make init` will remove any container/database/volume and init a new instance with data from the exported files

then `make start` will start a new instance (latest version), upgrading the previous database.


### TODO:

- [ ] replace secrets with real-values from envvars/other file
- [ ] use envars to select the source exported files and keycloak version for images
